### PR TITLE
hub: decline builds with no capable worker so Nix falls back locally

### DIFF
--- a/crates/tribuchet/src/config.rs
+++ b/crates/tribuchet/src/config.rs
@@ -28,6 +28,10 @@ pub struct HubConfig {
     /// Directory with the CA material and the hub TLS key pair.
     #[serde(default = "default_hub_config_dir")]
     pub config_dir: PathBuf,
+    /// Seconds to wait for a capable worker before declining a build
+    /// (lets a patched Nix fall back to a local build).
+    #[serde(default = "default_worker_grace_secs")]
+    pub worker_grace_secs: u64,
 }
 
 fn default_hub_socket() -> PathBuf {
@@ -38,6 +42,9 @@ fn default_hub_listen() -> String {
 }
 fn default_hub_config_dir() -> PathBuf {
     "/etc/tribuchet".into()
+}
+fn default_worker_grace_secs() -> u64 {
+    30
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/tribuchet/src/hub.rs
+++ b/crates/tribuchet/src/hub.rs
@@ -371,13 +371,16 @@ fn restrict_attach_socket(socket: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn run(socket: &Path, listen: &str, config_dir: &Path) -> Result<()> {
+pub fn run(cfg: crate::config::HubConfig) -> Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
-    rt.block_on(run_async(socket, listen, config_dir))
+    rt.block_on(run_async(cfg))
 }
 
-async fn run_async(socket: &Path, listen: &str, config_dir: &Path) -> Result<()> {
-    let state = Arc::new(HubState::default());
+async fn run_async(cfg: crate::config::HubConfig) -> Result<()> {
+    let socket = cfg.socket.as_path();
+    let listen = cfg.listen.as_str();
+    let config_dir = cfg.config_dir.as_path();
+    let state = Arc::new(HubState::new(std::time::Duration::from_secs(cfg.worker_grace_secs)));
 
     let ca_dir = config_dir.join("ca");
     let identity = Identity::from_pem(

--- a/crates/tribuchet/src/hub/state.rs
+++ b/crates/tribuchet/src/hub/state.rs
@@ -170,6 +170,8 @@ pub(super) struct HubState {
     /// forever.
     pub(super) worker_caps: std::sync::Mutex<HashMap<u64, WorkerCaps>>,
     pub(super) next_worker_id: atomic::AtomicU64,
+    /// Grace period before an unservable build is declined or failed.
+    pub(super) worker_grace: Duration,
 }
 
 #[derive(Clone)]
@@ -188,6 +190,12 @@ impl WorkerCaps {
 
 impl Default for HubState {
     fn default() -> Self {
+        Self::new(WORKER_GRACE)
+    }
+}
+
+impl HubState {
+    pub(super) fn new(worker_grace: Duration) -> Self {
         Self {
             queue: Mutex::default(),
             inflight: Mutex::default(),
@@ -198,6 +206,7 @@ impl Default for HubState {
             ),
             worker_caps: std::sync::Mutex::default(),
             next_worker_id: atomic::AtomicU64::default(),
+            worker_grace,
         }
     }
 }
@@ -248,7 +257,7 @@ impl HubState {
         self.notify.notify_waiters();
         let state = self.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(WORKER_GRACE + Duration::from_secs(1)).await;
+            tokio::time::sleep(state.worker_grace + Duration::from_secs(1)).await;
             state.fail_unservable().await;
         });
     }
@@ -275,7 +284,7 @@ impl HubState {
             // Requeued jobs get a grace period: their worker is mid
             // reload/restart and will re-announce them; a delayed
             // recheck is scheduled at requeue time.
-            let protected = j.requeued_at.is_some_and(|t| t.elapsed() < WORKER_GRACE);
+            let protected = j.requeued_at.is_some_and(|t| t.elapsed() < self.worker_grace);
             if protected || caps.iter().any(|c| c.serves(&j.req.system, &j.features)) {
                 kept.push_back(j);
             } else {

--- a/crates/tribuchet/src/hub/submit.rs
+++ b/crates/tribuchet/src/hub/submit.rs
@@ -10,8 +10,8 @@ use sha2::{Digest, Sha256};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
 
-use super::state::{HubState, Job, Replay, WORKER_GRACE};
-use crate::proto::{attach_hub_server, AttachEvent, BuildRequest};
+use super::state::{HubState, Job, Replay};
+use crate::proto::{attach_event, attach_hub_server, AttachEvent, BuildRequest};
 use crate::store::{valid_store_path, STORE_DIR};
 
 #[expect(
@@ -190,30 +190,32 @@ impl attach_hub_server::AttachHub for AttachSvc {
         let key = dedupe_key(&req);
 
         let features = crate::build_json::required_system_features(&req.env);
-        // Reject submissions no worker can serve, but only after a
-        // grace period: right after a hub restart the workers have not
-        // re-registered yet, and that must not fail client builds.
+        // Wait for a capable worker through the grace period (workers
+        // re-register after a hub restart); on timeout decline the build
+        // so a patched Nix falls back to a local build.
         let servable = || {
             let caps = self.state.worker_caps.lock().unwrap();
             caps.values().any(|c| c.serves(&req.system, &features))
         };
         if !servable() {
             tracing::info!(system = req.system, "no capable worker yet; waiting");
-            let deadline = Instant::now() + WORKER_GRACE;
+            let deadline = Instant::now() + self.state.worker_grace;
             loop {
                 tokio::time::sleep(std::time::Duration::from_millis(200)).await;
                 if servable() {
                     break;
                 }
                 if Instant::now() >= deadline {
-                    let what = if features.is_empty() {
-                        format!("system {}", req.system)
-                    } else {
-                        format!("system {} with features {features:?}", req.system)
-                    };
-                    return Err(Status::failed_precondition(format!(
-                        "no connected worker builds for {what}"
-                    )));
+                    tracing::info!(system = req.system, "no capable worker; declining");
+                    let (tx, rx) = tokio::sync::mpsc::channel(1);
+                    let _ = tx
+                        .send(Ok(AttachEvent {
+                            event: Some(attach_event::Event::ExitCode(
+                                crate::proto::DECLINE_EXIT_CODE,
+                            )),
+                        }))
+                        .await;
+                    return Ok(Response::new(ReceiverStream::new(rx)));
                 }
             }
         }

--- a/crates/tribuchet/src/main.rs
+++ b/crates/tribuchet/src/main.rs
@@ -71,7 +71,7 @@ fn main() -> anyhow::Result<()> {
         Command::Attach { build_json, socket } => attach::run(&build_json, &socket),
         Command::Hub { config } => {
             let cfg: config::HubConfig = config::load(&config)?;
-            hub::run(&cfg.socket, &cfg.listen, &cfg.config_dir)
+            hub::run(cfg)
         }
         Command::Worker { config } => {
             let cfg: config::WorkerConfig = config::load(&config)?;

--- a/crates/tribuchet/src/proto.rs
+++ b/crates/tribuchet/src/proto.rs
@@ -7,3 +7,7 @@ tonic::include_proto!("tribuchet.v1");
 /// carry the whole input closure; tonic's 4 MiB default rejects large
 /// but legitimate closures.
 pub const MAX_MSG_SIZE: usize = 64 * 1024 * 1024;
+
+/// Exit code the shim returns when the hub declines a build (no capable
+/// worker); a patched Nix treats it as "build locally instead".
+pub const DECLINE_EXIT_CODE: i32 = 222;

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -94,7 +94,11 @@ in
       patchNix = lib.mkOption {
         type = lib.types.bool;
         default = true;
-        description = "Patch Nix so uid-range derivations reach the external builder.";
+        description = ''
+          Patch Nix so uid-range derivations reach the external builder
+          and so a declined build (no worker for the system) falls back
+          to a local build instead of failing.
+        '';
       };
       recursiveNix = lib.mkOption {
         type = lib.types.bool;
@@ -139,7 +143,10 @@ in
       nix.package =
         let
           patches =
-            lib.optional hub.externalBuilders.patchNix ./patches/external-builders-uid-range.patch
+            lib.optionals hub.externalBuilders.patchNix [
+              ./patches/external-builders-uid-range.patch
+              ./patches/external-builders-decline-fallback.patch
+            ]
             ++ lib.optional hub.externalBuilders.recursiveNix ./patches/recursive-nix-external-builders.patch;
         in
         if patches == [ ] then

--- a/nix/patches/external-builders-decline-fallback.patch
+++ b/nix/patches/external-builders-decline-fallback.patch
@@ -1,0 +1,74 @@
+From: Tribuchet contributors
+Subject: [PATCH] external builders: fall back to local build on decline
+
+An external builder program may exit with a sentinel status to decline a
+build -- tribuchet's attach shim does this when the hub has no worker for
+the derivation's system. When the requesting host could build the
+derivation itself (matching platform, required system features, and a
+nonzero max-jobs), Nix retries it as a true local build instead of
+failing, keeping the already-held output locks. Foreign-system builds,
+which cannot run locally, still fail as before.
+
+diff --git a/src/libstore/build/derivation-building-goal.cc b/src/libstore/build/derivation-building-goal.cc
+index 81612b4db..295f98625 100644
+--- a/src/libstore/build/derivation-building-goal.cc
++++ b/src/libstore/build/derivation-building-goal.cc
+@@ -22,6 +22,9 @@
+ #include <sys/types.h>
+ #include <fcntl.h>
+ #include <unistd.h>
++#ifndef _WIN32
++#  include <sys/wait.h>
++#endif
+ 
+ #include <nlohmann/json.hpp>
+ 
+@@ -1052,6 +1055,30 @@ Goal::Co DerivationBuildingGoal::buildLocally(
+         builtOutputs = builder->unprepareBuild();
+     } catch (BuilderFailureError & e) {
+         builder.reset();
++
++        /* External builder declined; build locally if this host can. */
++        if (localBuildCap.externalBuilder && WIFEXITED(e.builderStatus)
++            && WEXITSTATUS(e.builderStatus) == externalBuilderDeclinedExitCode) {
++            bool platformOk = drv->platform == settings.thisSystem.get()
++                              || settings.extraPlatforms.get().count(drv->platform) || drv->isBuiltin();
++            auto required = drvOptions.getRequiredSystemFeatures(*drv);
++            auto & available = worker.store.config.systemFeatures.get();
++            bool featuresOk =
++                std::ranges::all_of(required, [&](const std::string & f) { return available.count(f); });
++            if (worker.settings.maxBuildJobs.get() != 0 && platformOk && featuresOk) {
++                debug(
++                    "external builder declined '%s'; falling back to a local build",
++                    worker.store.printStorePath(drvPath));
++                localBuildCap.externalBuilder = nullptr;
++                co_return buildLocally(
++                    std::move(localBuildCap),
++                    std::move(inputPaths),
++                    std::move(initialOutputs),
++                    std::move(drvOptions),
++                    std::move(outputLocks));
++            }
++        }
++
+         outputLocks.unlock();
+         co_return doneFailure(fixupBuilderFailureErrorMessage(std::move(e), *buildLog));
+     } catch (BuildError & e) {
+diff --git a/src/libstore/include/nix/store/build/derivation-builder.hh b/src/libstore/include/nix/store/build/derivation-builder.hh
+index ea2e46445..fef384da0 100644
+--- a/src/libstore/include/nix/store/build/derivation-builder.hh
++++ b/src/libstore/include/nix/store/build/derivation-builder.hh
+@@ -27,6 +27,13 @@ void rethrowExceptionAsError();
+  */
+ void handleChildException(bool sendException);
+ 
++/**
++ * Exit status with which an external builder declines a build, asking
++ * Nix to build it locally instead (used when no remote worker can serve
++ * the derivation's system).
++ */
++constexpr int externalBuilderDeclinedExitCode = 222;
++
+ /**
+  * Denotes a build failure that stemmed from the builder exiting with a
+  * failing exist status.

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -118,6 +118,8 @@ in
         imports = [ nixosModule ];
         services.tribuchet-hub = {
           enable = true;
+          # keep the no-worker decline quick for the fallback subtest
+          settings.worker-grace-secs = 2;
           externalBuilders = {
             enable = true;
             recursiveNix = true;
@@ -377,12 +379,14 @@ in
             out = hub.succeed("nix-build /etc/tt/kvm.nix --no-out-link").strip()
             hub.succeed(f"grep -q kvm-ok {out}")
         else:
+            # No worker serves the kvm feature and the hub cannot build it
+            # locally either, so the declined build (exit 222) fails.
             err = hub.fail("nix-build /etc/tt/kvm.nix --no-out-link 2>&1")
-            assert "no connected worker" in err, err
+            assert "exit code 222" in err, err
 
     with subtest("emulated system does not inherit the host's kvm feature"):
         err = hub.fail("nix-build /etc/tt/kvm-emulated.nix --no-out-link 2>&1")
-        assert "no connected worker" in err, err
+        assert "exit code 222" in err, err
 
     with subtest("runaway build log is killed at max-log-size"):
         err = hub.fail("nix-build /etc/tt/logbomb.nix --no-out-link 2>&1")
@@ -418,6 +422,31 @@ in
     with subtest("systemd-nspawn boots a NixOS container in a remote build"):
         out = hub.succeed("nix-build /etc/tt/nspawn.nix --no-out-link", timeout=1800).strip()
         hub.succeed(f"[[ $(cat {out}/msg) = 'Hello World' ]]")
+
+    with subtest("no worker: build is declined and falls back to a local build"):
+        worker.succeed("systemctl stop tribuchet-worker")
+        # let the hub observe the worker's session tear down so it no
+        # longer counts as capable
+        hub.succeed("sleep 3")
+        hub.succeed("echo fallback-payload > /root/fallback")
+        uniq = hub.succeed("nix-store --add /root/fallback").strip()
+        hub.succeed(
+            "cat > /root/fallback.nix << 'NIXEOF'\n"
+            "let\n"
+            '  bash = builtins.storePath "${pkgs.bash}";\n'
+            f'  uniq = builtins.storePath "{uniq}";\n'
+            "in derivation {\n"
+            '  name = "tt-fallback-build";\n'
+            '  system = "x86_64-linux";\n'
+            '  builder = bash + "/bin/bash";\n'
+            '  args = [ "-c" ("read line < " + uniq + "; echo \\"$line built-locally\\" > $out") ];\n'
+            "}\n"
+            "NIXEOF"
+        )
+        out = hub.succeed("nix-build /root/fallback.nix --no-out-link", timeout=120).strip()
+        hub.succeed(f"grep -q 'fallback-payload built-locally' {out}")
+        hub.succeed("journalctl -u tribuchet-hub | grep -q 'no capable worker; declining'")
+        worker.succeed("systemctl start tribuchet-worker")
 
     with subtest("build really ran on the worker"):
         worker.succeed("journalctl -u tribuchet-worker | grep -q 'builder finished'")


### PR DESCRIPTION

When no worker can serve a submitted build within the grace period, the
hub now streams a decline exit code (222) instead of a hard error. A Nix
patched with external-builders-decline-fallback then retries the build
locally if the host can serve it. The grace period is configurable via
worker-grace-secs (default 30).
