### PR TITLE
attach: report the worker instead of logging every unpacked output

### DIFF
--- a/crates/tribuchet/proto/tribuchet.proto
+++ b/crates/tribuchet/proto/tribuchet.proto
@@ -223,6 +223,9 @@ message AttachEvent {
     // (recursive-nix extra). Goes into result.json for Nix's output
     // reference scan.
     string added_path = 6;
+    // Name of the worker the build was dispatched to, for the client
+    // to report where the build runs.
+    string dispatched = 7;
   }
 }
 

--- a/crates/tribuchet/src/attach.rs
+++ b/crates/tribuchet/src/attach.rs
@@ -167,6 +167,9 @@ async fn attempt_build(
             Some(attach_event::Event::AddedPath(path)) => {
                 added_paths.insert(path);
             }
+            Some(attach_event::Event::Dispatched(worker)) => {
+                eprintln!("tribuchet: building on {worker}");
+            }
             Some(attach_event::Event::OutputRestart(path)) => {
                 // The previous worker attempt died mid-NAR; the next
                 // attempt streams this output again from the start.
@@ -271,7 +274,7 @@ async fn handle_output_chunk(
         remove_tree(Path::new(&out.store_path));
         std::fs::rename(&tmp, &out.store_path)
             .with_context(|| format!("moving output into place at {}", out.store_path))?;
-        tracing::info!(path = out.store_path, "output unpacked");
+        tracing::debug!(path = out.store_path, "output unpacked");
     }
     Ok(())
 }

--- a/crates/tribuchet/src/hub.rs
+++ b/crates/tribuchet/src/hub.rs
@@ -283,6 +283,10 @@ async fn worker_loop(
             worker = register.worker_name,
             "dispatching build"
         );
+        // Tell the attach client where its build runs.
+        job.replay
+            .publish(attach_event::Event::Dispatched(register.worker_name.clone()))
+            .await;
         Metrics::inc(&state.metrics.dispatched);
         let in_rx = router.register(&job.id);
         let state = state.clone();

--- a/crates/tribuchet/src/hub/state.rs
+++ b/crates/tribuchet/src/hub/state.rs
@@ -52,7 +52,9 @@ fn event_size(ev: &attach_event::Event) -> usize {
     match ev {
         attach_event::Event::Log(d) => d.len(),
         attach_event::Event::Output(o) => o.zstd_nar_chunk.len(),
-        attach_event::Event::OutputRestart(p) | attach_event::Event::AddedPath(p) => p.len(),
+        attach_event::Event::OutputRestart(p)
+        | attach_event::Event::AddedPath(p)
+        | attach_event::Event::Dispatched(p) => p.len(),
         attach_event::Event::Error(e) => e.len(),
         attach_event::Event::ExitCode(_) => 0,
     }


### PR DESCRIPTION

The external-builder shim logged an info line per unpacked output, so a
client building a large closure through the hub emitted a wall of
near-identical "output unpacked" lines that drowned the build log
without saying anything useful. Demote that to debug and have the hub
announce, once per dispatch, which worker the build runs on, so the log
shows where work happened rather than every file that came back.
