### PR TITLE
build: cache cargo deps with crane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "harmonia-file-core"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=773c2f5635c4e38e7fb932b5e22a80d23b279153#773c2f5635c4e38e7fb932b5e22a80d23b279153"
+source = "git+https://github.com/nix-community/harmonia?rev=0760dbe508a1162f05dc36bdf333b45318ee77a0#0760dbe508a1162f05dc36bdf333b45318ee77a0"
 dependencies = [
  "serde",
  "serde_json",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "harmonia-file-nar"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=773c2f5635c4e38e7fb932b5e22a80d23b279153#773c2f5635c4e38e7fb932b5e22a80d23b279153"
+source = "git+https://github.com/nix-community/harmonia?rev=0760dbe508a1162f05dc36bdf333b45318ee77a0#0760dbe508a1162f05dc36bdf333b45318ee77a0"
 dependencies = [
  "bstr",
  "bytes",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "harmonia-protocol"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=773c2f5635c4e38e7fb932b5e22a80d23b279153#773c2f5635c4e38e7fb932b5e22a80d23b279153"
+source = "git+https://github.com/nix-community/harmonia?rev=0760dbe508a1162f05dc36bdf333b45318ee77a0#0760dbe508a1162f05dc36bdf333b45318ee77a0"
 dependencies = [
  "async-stream",
  "bstr",
@@ -845,7 +845,7 @@ dependencies = [
 [[package]]
 name = "harmonia-protocol-derive"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=773c2f5635c4e38e7fb932b5e22a80d23b279153#773c2f5635c4e38e7fb932b5e22a80d23b279153"
+source = "git+https://github.com/nix-community/harmonia?rev=0760dbe508a1162f05dc36bdf333b45318ee77a0#0760dbe508a1162f05dc36bdf333b45318ee77a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -855,7 +855,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-aterm"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia?rev=773c2f5635c4e38e7fb932b5e22a80d23b279153#773c2f5635c4e38e7fb932b5e22a80d23b279153"
+source = "git+https://github.com/nix-community/harmonia?rev=0760dbe508a1162f05dc36bdf333b45318ee77a0#0760dbe508a1162f05dc36bdf333b45318ee77a0"
 dependencies = [
  "bytes",
  "harmonia-store-content-address",
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-build-result"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=773c2f5635c4e38e7fb932b5e22a80d23b279153#773c2f5635c4e38e7fb932b5e22a80d23b279153"
+source = "git+https://github.com/nix-community/harmonia?rev=0760dbe508a1162f05dc36bdf333b45318ee77a0#0760dbe508a1162f05dc36bdf333b45318ee77a0"
 dependencies = [
  "harmonia-store-derivation",
  "num_enum",
@@ -882,7 +882,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-content-address"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=773c2f5635c4e38e7fb932b5e22a80d23b279153#773c2f5635c4e38e7fb932b5e22a80d23b279153"
+source = "git+https://github.com/nix-community/harmonia?rev=0760dbe508a1162f05dc36bdf333b45318ee77a0#0760dbe508a1162f05dc36bdf333b45318ee77a0"
 dependencies = [
  "derive_more",
  "harmonia-store-path",
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-derivation"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia?rev=773c2f5635c4e38e7fb932b5e22a80d23b279153#773c2f5635c4e38e7fb932b5e22a80d23b279153"
+source = "git+https://github.com/nix-community/harmonia?rev=0760dbe508a1162f05dc36bdf333b45318ee77a0#0760dbe508a1162f05dc36bdf333b45318ee77a0"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-path"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=773c2f5635c4e38e7fb932b5e22a80d23b279153#773c2f5635c4e38e7fb932b5e22a80d23b279153"
+source = "git+https://github.com/nix-community/harmonia?rev=0760dbe508a1162f05dc36bdf333b45318ee77a0#0760dbe508a1162f05dc36bdf333b45318ee77a0"
 dependencies = [
  "derive_more",
  "harmonia-utils-base-encoding",
@@ -926,7 +926,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-path-info"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=773c2f5635c4e38e7fb932b5e22a80d23b279153#773c2f5635c4e38e7fb932b5e22a80d23b279153"
+source = "git+https://github.com/nix-community/harmonia?rev=0760dbe508a1162f05dc36bdf333b45318ee77a0#0760dbe508a1162f05dc36bdf333b45318ee77a0"
 dependencies = [
  "harmonia-store-content-address",
  "harmonia-store-path",
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-ref-scan"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia?rev=773c2f5635c4e38e7fb932b5e22a80d23b279153#773c2f5635c4e38e7fb932b5e22a80d23b279153"
+source = "git+https://github.com/nix-community/harmonia?rev=0760dbe508a1162f05dc36bdf333b45318ee77a0#0760dbe508a1162f05dc36bdf333b45318ee77a0"
 dependencies = [
  "harmonia-store-path",
  "harmonia-utils-base-encoding",
@@ -947,7 +947,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-remote"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=773c2f5635c4e38e7fb932b5e22a80d23b279153#773c2f5635c4e38e7fb932b5e22a80d23b279153"
+source = "git+https://github.com/nix-community/harmonia?rev=0760dbe508a1162f05dc36bdf333b45318ee77a0#0760dbe508a1162f05dc36bdf333b45318ee77a0"
 dependencies = [
  "async-stream",
  "futures-core",
@@ -967,7 +967,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-base-encoding"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia?rev=773c2f5635c4e38e7fb932b5e22a80d23b279153#773c2f5635c4e38e7fb932b5e22a80d23b279153"
+source = "git+https://github.com/nix-community/harmonia?rev=0760dbe508a1162f05dc36bdf333b45318ee77a0#0760dbe508a1162f05dc36bdf333b45318ee77a0"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -977,7 +977,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-hash"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia?rev=773c2f5635c4e38e7fb932b5e22a80d23b279153#773c2f5635c4e38e7fb932b5e22a80d23b279153"
+source = "git+https://github.com/nix-community/harmonia?rev=0760dbe508a1162f05dc36bdf333b45318ee77a0#0760dbe508a1162f05dc36bdf333b45318ee77a0"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -995,7 +995,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-io"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia?rev=773c2f5635c4e38e7fb932b5e22a80d23b279153#773c2f5635c4e38e7fb932b5e22a80d23b279153"
+source = "git+https://github.com/nix-community/harmonia?rev=0760dbe508a1162f05dc36bdf333b45318ee77a0#0760dbe508a1162f05dc36bdf333b45318ee77a0"
 dependencies = [
  "bytes",
  "futures-util",
@@ -1008,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-signature"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=773c2f5635c4e38e7fb932b5e22a80d23b279153#773c2f5635c4e38e7fb932b5e22a80d23b279153"
+source = "git+https://github.com/nix-community/harmonia?rev=0760dbe508a1162f05dc36bdf333b45318ee77a0#0760dbe508a1162f05dc36bdf333b45318ee77a0"
 dependencies = [
  "data-encoding",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,9 @@ futures-util = "0.3"
 async-compression = { version = "0.4", features = ["tokio", "zstd"] }
 tokio-util = { version = "0.7", features = ["io"] }
 bytes = "1"
-harmonia-file-nar = { git = "https://github.com/nix-community/harmonia", rev = "773c2f5635c4e38e7fb932b5e22a80d23b279153" }
-harmonia-store-path = { git = "https://github.com/nix-community/harmonia", rev = "773c2f5635c4e38e7fb932b5e22a80d23b279153" }
-harmonia-store-path-info = { git = "https://github.com/nix-community/harmonia", rev = "773c2f5635c4e38e7fb932b5e22a80d23b279153" }
-harmonia-utils-signature = { git = "https://github.com/nix-community/harmonia", rev = "773c2f5635c4e38e7fb932b5e22a80d23b279153" }
-harmonia-store-remote = { git = "https://github.com/nix-community/harmonia", rev = "773c2f5635c4e38e7fb932b5e22a80d23b279153" }
-harmonia-store-ref-scan = { git = "https://github.com/nix-community/harmonia", rev = "773c2f5635c4e38e7fb932b5e22a80d23b279153" }
+harmonia-file-nar = { git = "https://github.com/nix-community/harmonia", rev = "0760dbe508a1162f05dc36bdf333b45318ee77a0" }
+harmonia-store-path = { git = "https://github.com/nix-community/harmonia", rev = "0760dbe508a1162f05dc36bdf333b45318ee77a0" }
+harmonia-store-path-info = { git = "https://github.com/nix-community/harmonia", rev = "0760dbe508a1162f05dc36bdf333b45318ee77a0" }
+harmonia-utils-signature = { git = "https://github.com/nix-community/harmonia", rev = "0760dbe508a1162f05dc36bdf333b45318ee77a0" }
+harmonia-store-remote = { git = "https://github.com/nix-community/harmonia", rev = "0760dbe508a1162f05dc36bdf333b45318ee77a0" }
+harmonia-store-ref-scan = { git = "https://github.com/nix-community/harmonia", rev = "0760dbe508a1162f05dc36bdf333b45318ee77a0" }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1781825982,
+        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -38,6 +53,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
   description = "tribuchet - RBE-style remote build execution for Nix";
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.crane.url = "github:ipetkov/crane";
   # only used to evaluate the darwin module in checks
   inputs.nix-darwin = {
     url = "github:nix-darwin/nix-darwin";
@@ -12,6 +13,7 @@
     {
       self,
       nixpkgs,
+      crane,
       nix-darwin,
     }:
     let
@@ -34,7 +36,9 @@
           ./nix/patches/recursive-nix-external-builders.patch
         ];
 
-        default = pkgs.callPackage ./nix/package.nix { };
+        default = pkgs.callPackage ./nix/package.nix {
+          craneLib = crane.mkLib pkgs;
+        };
       });
 
       darwinModules.default = import ./nix/darwin-module.nix self;

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,40 +1,42 @@
 {
   lib,
-  rustPlatform,
   stdenv,
+  craneLib,
   protobuf,
   passt,
 }:
 let
   # repository root is one level up from this file
   root = ./..;
-in
-rustPlatform.buildRustPackage (
-  {
+  src = lib.fileset.toSource {
+    inherit root;
+    fileset = lib.fileset.unions [
+      (root + "/Cargo.toml")
+      (root + "/Cargo.lock")
+      (root + "/crates")
+    ];
+  };
+
+  commonArgs = {
     pname = "tribuchet";
     version = "0.1.0";
-    src = lib.fileset.toSource {
-      inherit root;
-      fileset = lib.fileset.unions [
-        (root + "/Cargo.toml")
-        (root + "/Cargo.lock")
-        (root + "/crates")
-      ];
-    };
-    cargoLock = {
-      lockFile = root + "/Cargo.lock";
-      # harmonia crates come from one pinned git rev; builtin
-      # fetchGit avoids enumerating an outputHash per crate
-      allowBuiltinFetchGit = true;
-    };
+    inherit src;
+    strictDeps = true;
     nativeBuildInputs = [ protobuf ];
     PROTOC = "${protobuf}/bin/protoc";
+  };
+
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+in
+craneLib.buildPackage (
+  commonArgs
+  // {
+    inherit cargoArtifacts;
     # sandbox_runs_builder needs CAP_SYS_ADMIN that the outer
     # Nix builder sandbox does not grant; `nix develop -c
     # cargo test` runs it.
-    checkFlags = [
-      "--skip=worker::sandbox::tests::sandbox_runs_builder"
-    ];
+    cargoTestExtraArgs = "-- --skip=worker::sandbox::tests::sandbox_runs_builder";
+    passthru = { inherit cargoArtifacts; };
   }
   // lib.optionalAttrs stdenv.isLinux {
     # default network backend for fixed-output builds


### PR DESCRIPTION
rustPlatform.buildRustPackage rebuilds every crate in Cargo.lock on
any source change.  Splitting the build into crane's buildDepsOnly +
buildPackage keeps the ~300 dependency crates (incl. the harmonia git
deps and tonic-build) in their own derivation that only rebuilds when
Cargo.{toml,lock} change, taking incremental builds from ~3m to ~30s.

Bumps the harmonia rev past nix-community/harmonia#1091 so crane's
git-dep vendoring (which runs cargo package -l) no longer trips on
harmonia-store-ref-scan's missing README.
