### PR TITLE
chore: drop unused direct ed25519-dalek dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,6 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
  "subtle",
@@ -2416,7 +2415,6 @@ dependencies = [
  "async-compression",
  "bytes",
  "clap",
- "ed25519-dalek",
  "futures-util",
  "harmonia-file-nar",
  "harmonia-store-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ doc_markdown = "allow"
 [workspace.dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-ed25519-dalek = { version = "2", features = ["rand_core"] }
 hex = "0.4"
 hyper-util = "0.1"
 nix = { version = "0.31", features = ["dir", "mount", "sched", "user", "fs", "hostname", "signal", "process", "resource", "personality", "socket", "uio"] }

--- a/crates/tribuchet/Cargo.toml
+++ b/crates/tribuchet/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-ed25519-dalek.workspace = true
 hex.workspace = true
 hyper-util.workspace = true
 prost.workspace = true


### PR DESCRIPTION
Nothing in src/ imports it; signatures go through
harmonia-utils-signature, which already pulls ed25519-dalek
transitively.  The rand_core feature was only needed for
SigningKey::generate, which we never call.
