### PR TITLE
feat: tailscale auth mode as an alternative to mTLS

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -126,16 +126,21 @@ signatures).
 
 ## Security
 
-* Transport: mTLS; `tribuchet ca` issues the CA and per-worker certs
-  (finite validity: 10y CA, 2y leaves; no revocation yet — rotate the CA
-  if a worker key leaks).
+* Transport: mTLS by default; `tribuchet ca` issues the CA and
+  per-worker certs (finite validity: 10y CA, 2y leaves; no revocation
+  yet — rotate the CA if a worker key leaks). With `auth =
+  "tailscale"` the listener runs plaintext and the hub asks
+  tailscaled's LocalAPI `whois` for the peer's node name and ACL tags
+  on each session, so WireGuard provides confidentiality/integrity
+  and the tailnet provides identity (optionally gated to
+  `tailscale-allowed-tags`).
 * Output authenticity: workers sign output NARs (ed25519); the hub
   verifies while relaying. By default the key is the one the worker
-  registers over its mTLS session; with a `trusted-signing-keys` file in
+  registers over its authenticated session; with a `trusted-signing-keys` file in
   the hub config dir (one Nix-format `name:base64` public key per line,
   same syntax as nix.conf `trusted-public-keys`) registration is
-  restricted to pinned keys, so a stolen TLS cert alone cannot serve
-  validly-signed outputs.
+  restricted to pinned keys, so a stolen transport credential alone
+  cannot serve validly-signed outputs.
 * The attach socket is group-restricted to `nixbld` (the hub refuses to
   start without that group). Request validation pins every client-chosen
   path; `topTmpDir` must be owned by the connecting peer.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ The hub reads `ca/{hub.crt,hub.key,ca.crt}` from `<config-dir>/ca`
 (default `/etc/tribuchet/ca`); each worker gets `ca.crt` plus its own
 key pair (default `/var/lib/tribuchet/tls/`).
 
+Alternatively, set `auth = "tailscale"` on both sides to skip TLS
+entirely: the worker dials `http://<hub-tailnet-name>:7437`, the hub
+looks the peer up against tailscaled's LocalAPI on each connection
+(so anything not on the tailnet is rejected) and uses the node name
+as the worker identity. Gate registration to specific ACL tags with
+`tailscale-allowed-tags = ["tag:tribuchet-worker"]`.
+
 ### 2. Hub (on the machine running nix-daemon)
 
 `/etc/tribuchet/hub.toml`:

--- a/crates/tribuchet/src/config.rs
+++ b/crates/tribuchet/src/config.rs
@@ -10,6 +10,18 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
+/// How the worker listener authenticates peers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Auth {
+    /// Mutual TLS against the `tribuchet ca` root (default).
+    #[default]
+    Mtls,
+    /// No TLS; identity comes from tailscaled's LocalAPI `whois`.
+    /// Transport security is the WireGuard tunnel.
+    Tailscale,
+}
+
 pub fn load<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T> {
     let text = std::fs::read_to_string(path)
         .with_context(|| format!("reading config file {}", path.display()))?;
@@ -19,6 +31,9 @@ pub fn load<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T> {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct HubConfig {
+    /// Worker authentication mode.
+    #[serde(default)]
+    pub auth: Auth,
     /// Unix socket `tribuchet attach` connects to.
     #[serde(default = "default_hub_socket")]
     pub socket: PathBuf,
@@ -39,6 +54,13 @@ pub struct HubConfig {
     /// metrics endpoint; disabled when unset.
     #[serde(default)]
     pub metrics_listen: Option<String>,
+    /// tailscaled LocalAPI socket (auth = tailscale).
+    #[serde(default = "default_tailscale_socket")]
+    pub tailscale_socket: PathBuf,
+    /// When set, only nodes carrying one of these ACL tags may
+    /// register as a worker (auth = tailscale).
+    #[serde(default)]
+    pub tailscale_allowed_tags: Vec<String>,
 }
 
 fn default_hub_socket() -> PathBuf {
@@ -53,12 +75,19 @@ fn default_hub_config_dir() -> PathBuf {
 fn default_worker_grace_secs() -> u64 {
     30
 }
+fn default_tailscale_socket() -> PathBuf {
+    "/var/run/tailscale/tailscaled.sock".into()
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct WorkerConfig {
-    /// Hub gRPC address, e.g. https://hub.example.org:7437
+    /// Hub gRPC address, e.g. https://hub.example.org:7437 (mTLS) or
+    /// http://hub:7437 (tailscale).
     pub hub: String,
+    /// Hub authentication mode; must match the hub.
+    #[serde(default)]
+    pub auth: Auth,
     #[serde(default = "default_state_dir")]
     pub state_dir: PathBuf,
     /// Systems this worker builds for (default: host system).

--- a/crates/tribuchet/src/hub.rs
+++ b/crates/tribuchet/src/hub.rs
@@ -20,8 +20,10 @@ use nix::sys::stat;
 use nix::unistd::Group;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::{ReceiverStream, UnixListenerStream};
-use tonic::transport::{Certificate, Identity, Server, ServerTlsConfig};
+use tonic::transport::{server::TcpConnectInfo, Certificate, Identity, Server, ServerTlsConfig};
 use tonic::{Request, Response, Status, Streaming};
+
+use crate::config::Auth;
 
 use crate::proto::{
     attach_event, attach_hub_server, hub_message, worker_message, CancelBuild, HubMessage,
@@ -45,12 +47,25 @@ const WORKER_SILENCE_TIMEOUT: Duration = Duration::from_mins(3);
 /// A worker-session loss requeues a job at most this many times.
 const MAX_JOB_ATTEMPTS: u32 = 3;
 
+/// In tailscale mode the hub asks tailscaled who the peer is on every
+/// session and uses that as the worker name; mTLS mode trusts the
+/// transport layer (only certs signed by our CA can connect) and the
+/// self-reported name.
+enum PeerAuth {
+    Mtls,
+    Tailscale {
+        socket: std::path::PathBuf,
+        allowed_tags: Vec<String>,
+    },
+}
+
 struct WorkerSvc {
     state: Arc<HubState>,
+    auth: Arc<PeerAuth>,
     /// Operator-pinned worker signing keys; when configured, a worker
     /// registering an unknown key is rejected. Without it the signature
     /// check only proves the NARs came from whoever registered the key,
-    /// which mTLS already guarantees.
+    /// which the transport auth already guarantees.
     trusted_keys: Option<Arc<Vec<PublicKey>>>,
 }
 
@@ -170,13 +185,44 @@ impl crate::proto::worker_hub_server::WorkerHub for WorkerSvc {
         &self,
         request: Request<Streaming<WorkerMessage>>,
     ) -> Result<Response<Self::SessionStream>, Status> {
+        let remote = request
+            .extensions()
+            .get::<TcpConnectInfo>()
+            .and_then(|i| i.remote_addr);
         let mut inbound = request.into_inner();
         let Some(WorkerMessage {
-            msg: Some(worker_message::Msg::Register(register)),
+            msg: Some(worker_message::Msg::Register(mut register)),
         }) = inbound.message().await?
         else {
             return Err(Status::invalid_argument("first message must be Register"));
         };
+        if let PeerAuth::Tailscale {
+            socket,
+            allowed_tags,
+        } = self.auth.as_ref()
+        {
+            let Some(addr) = remote else {
+                return Err(Status::unauthenticated("no peer address"));
+            };
+            let who = crate::tailscale::whois(socket, addr).await.map_err(|e| {
+                tracing::warn!(%addr, "tailscale whois failed: {e:#}");
+                Status::unauthenticated("peer is not on the tailnet")
+            })?;
+            if !allowed_tags.is_empty() && !who.tags.iter().any(|t| allowed_tags.contains(t)) {
+                tracing::warn!(
+                    node = who.node_name,
+                    tags = ?who.tags,
+                    "rejecting worker without an allowed tailscale tag"
+                );
+                return Err(Status::permission_denied(
+                    "tailscale node tag not in tailscale-allowed-tags",
+                ));
+            }
+            // The tailnet-asserted name is authoritative; the worker's
+            // self-reported one would let any tailnet peer impersonate
+            // another in logs and metrics.
+            register.worker_name = who.node_name;
+        }
         let vkey: PublicKey = register
             .signing_public_key
             .parse()
@@ -423,6 +469,41 @@ fn load_trusted_keys(config_dir: &Path) -> Result<Option<Arc<Vec<PublicKey>>>> {
     }
 }
 
+fn configure_auth(
+    cfg: &crate::config::HubConfig,
+    config_dir: &Path,
+) -> Result<(Option<ServerTlsConfig>, PeerAuth)> {
+    Ok(match cfg.auth {
+        Auth::Mtls => {
+            let ca_dir = config_dir.join("ca");
+            let identity = Identity::from_pem(
+                fs::read(ca_dir.join("hub.crt")).context("reading hub.crt")?,
+                fs::read(ca_dir.join("hub.key")).context("reading hub.key")?,
+            );
+            let ca =
+                Certificate::from_pem(fs::read(ca_dir.join("ca.crt")).context("reading ca.crt")?);
+            (
+                Some(ServerTlsConfig::new().identity(identity).client_ca_root(ca)),
+                PeerAuth::Mtls,
+            )
+        }
+        Auth::Tailscale => {
+            tracing::info!(
+                socket = %cfg.tailscale_socket.display(),
+                allowed_tags = ?cfg.tailscale_allowed_tags,
+                "tailscale auth: TLS disabled, identity via tailscaled whois"
+            );
+            (
+                None,
+                PeerAuth::Tailscale {
+                    socket: cfg.tailscale_socket.clone(),
+                    allowed_tags: cfg.tailscale_allowed_tags.clone(),
+                },
+            )
+        }
+    })
+}
+
 pub fn run(cfg: crate::config::HubConfig) -> Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(run_async(cfg))
@@ -436,14 +517,7 @@ async fn run_async(cfg: crate::config::HubConfig) -> Result<()> {
         cfg.worker_grace_secs,
     )));
 
-    let ca_dir = config_dir.join("ca");
-    let identity = Identity::from_pem(
-        fs::read(ca_dir.join("hub.crt")).context("reading hub.crt")?,
-        fs::read(ca_dir.join("hub.key")).context("reading hub.key")?,
-    );
-    let ca = Certificate::from_pem(fs::read(ca_dir.join("ca.crt")).context("reading ca.crt")?);
-    let tls = ServerTlsConfig::new().identity(identity).client_ca_root(ca);
-
+    let (tls, peer_auth) = configure_auth(&cfg, config_dir)?;
     let trusted_keys = load_trusted_keys(config_dir)?;
 
     // Listeners come from systemd socket activation when available
@@ -463,8 +537,11 @@ async fn run_async(cfg: crate::config::HubConfig) -> Result<()> {
         .await
         .context("binding worker listen address")?,
     };
-    let worker_server = Server::builder()
-        .tls_config(tls)?
+    let mut builder = Server::builder();
+    if let Some(tls) = tls {
+        builder = builder.tls_config(tls)?;
+    }
+    let worker_server = builder
         // Detect dead/half-open worker connections instead of relying on
         // the workers' own traffic.
         .http2_keepalive_interval(Some(Duration::from_secs(30)))
@@ -472,6 +549,7 @@ async fn run_async(cfg: crate::config::HubConfig) -> Result<()> {
         .add_service(
             crate::proto::worker_hub_server::WorkerHubServer::new(WorkerSvc {
                 state: state.clone(),
+                auth: Arc::new(peer_auth),
                 trusted_keys,
             })
             .max_decoding_message_size(MAX_MSG_SIZE)

--- a/crates/tribuchet/src/main.rs
+++ b/crates/tribuchet/src/main.rs
@@ -9,6 +9,7 @@ mod nar;
 mod proto;
 mod sd;
 mod store;
+mod tailscale;
 mod worker;
 
 use std::path::PathBuf;

--- a/crates/tribuchet/src/tailscale.rs
+++ b/crates/tribuchet/src/tailscale.rs
@@ -1,0 +1,110 @@
+//! Tailscale LocalAPI client used when `auth = "tailscale"`.
+//!
+//! In that mode the worker listener runs without TLS and trusts the
+//! WireGuard tunnel for confidentiality and integrity. Identity comes
+//! from tailscaled: for each incoming TCP connection the hub asks
+//! `GET /localapi/v0/whois?addr=<peer>` over the LocalAPI unix
+//! socket, which returns the tailnet node name and tags. A peer
+//! tailscaled does not know is rejected, so binding to the tailnet
+//! interface is not required for correctness (only for attack
+//! surface).
+
+use std::net::SocketAddr;
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+#[derive(Debug)]
+pub struct WhoIs {
+    /// Short tailnet node name (first DNS label of `Node.Name`).
+    pub node_name: String,
+    /// ACL tags applied to the node, e.g. `tag:tribuchet-worker`.
+    pub tags: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct Resp {
+    #[serde(rename = "Node")]
+    node: Node,
+}
+
+#[derive(Deserialize)]
+struct Node {
+    #[serde(rename = "Name")]
+    name: String,
+    #[serde(rename = "Tags", default)]
+    tags: Vec<String>,
+}
+
+/// Resolve `addr` against the local tailscaled. The LocalAPI on Linux
+/// is an HTTP/1.1 server on a unix socket; access control is the
+/// socket's file mode, so no Authorization header is needed.
+pub async fn whois(socket: &Path, addr: SocketAddr) -> Result<WhoIs> {
+    let mut s = tokio::net::UnixStream::connect(socket)
+        .await
+        .with_context(|| format!("connecting to tailscaled at {}", socket.display()))?;
+    // Host header is a fixed sentinel the daemon expects; the path
+    // takes the full ip:port so tailscaled can match the exact
+    // 4-tuple it NATed.
+    let req = format!(
+        "GET /localapi/v0/whois?addr={addr} HTTP/1.1\r\n\
+         Host: local-tailscaled.sock\r\n\
+         Connection: close\r\n\r\n"
+    );
+    s.write_all(req.as_bytes()).await?;
+    let mut buf = Vec::new();
+    s.read_to_end(&mut buf).await?;
+    let body = http_body(&buf)?;
+    let resp: Resp = serde_json::from_slice(body)
+        .with_context(|| format!("parsing whois response for {addr}"))?;
+    Ok(WhoIs {
+        node_name: resp
+            .node
+            .name
+            .split('.')
+            .next()
+            .unwrap_or(&resp.node.name)
+            .to_owned(),
+        tags: resp.node.tags,
+    })
+}
+
+/// Split status line / headers from body and check for 200. Supports
+/// the `Connection: close` framing we asked for; tailscaled does not
+/// chunk these tiny responses.
+fn http_body(buf: &[u8]) -> Result<&[u8]> {
+    let sep = buf
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .context("malformed HTTP response from tailscaled")?;
+    let head = std::str::from_utf8(&buf[..sep]).context("non-utf8 HTTP head")?;
+    let status = head.lines().next().unwrap_or_default();
+    if !status.contains(" 200 ") {
+        bail!("tailscaled whois: {status}");
+    }
+    Ok(&buf[sep + 4..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_whois_body() {
+        let raw = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n\
+            {\"Node\":{\"Name\":\"worker-1.tailnet.ts.net.\",\"Tags\":[\"tag:ci\"]},\
+             \"UserProfile\":{}}";
+        let body = http_body(raw).unwrap();
+        let r: Resp = serde_json::from_slice(body).unwrap();
+        assert_eq!(r.node.name, "worker-1.tailnet.ts.net.");
+        assert_eq!(r.node.tags, vec!["tag:ci"]);
+    }
+
+    #[test]
+    fn non_200_is_error() {
+        let raw = b"HTTP/1.1 404 Not Found\r\n\r\nno match";
+        assert!(http_body(raw).is_err());
+    }
+}

--- a/crates/tribuchet/src/worker.rs
+++ b/crates/tribuchet/src/worker.rs
@@ -41,7 +41,7 @@ use resume::{
     try_deliver, ResumableBuild,
 };
 
-use crate::config::WorkerConfig;
+use crate::config::{Auth, WorkerConfig};
 use crate::proto::{
     hub_message, worker_hub_client::WorkerHubClient, worker_message, BuildAssignment, BuildResult,
     Heartbeat, MissingPaths, Register, RequestJob, Resumed, WorkerMessage,
@@ -380,16 +380,19 @@ async fn session(
     signing_key: &Arc<SecretKey>,
     ctx: &Arc<WorkerCtx>,
 ) -> Result<()> {
-    let tls = ClientTlsConfig::new()
-        .ca_certificate(Certificate::from_pem(
-            fs::read(&opts.ca_cert).context("reading CA cert")?,
-        ))
-        .identity(Identity::from_pem(
-            fs::read(&opts.cert).context("reading worker cert")?,
-            fs::read(&opts.key).context("reading worker key")?,
-        ));
-    let channel = Endpoint::from_shared(opts.hub.clone())?
-        .tls_config(tls)?
+    let mut endpoint = Endpoint::from_shared(opts.hub.clone())?;
+    if matches!(opts.auth, Auth::Mtls) {
+        let tls = ClientTlsConfig::new()
+            .ca_certificate(Certificate::from_pem(
+                fs::read(&opts.ca_cert).context("reading CA cert")?,
+            ))
+            .identity(Identity::from_pem(
+                fs::read(&opts.cert).context("reading worker cert")?,
+                fs::read(&opts.key).context("reading worker key")?,
+            ));
+        endpoint = endpoint.tls_config(tls)?;
+    }
+    let channel = endpoint
         // Detect a silently dead hub connection instead of waiting on a
         // half-open TCP session forever.
         .http2_keep_alive_interval(Duration::from_secs(30))

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,13 @@
             }
           );
 
+          nixos-test-tailscale = pkgs.testers.runNixOSTest (
+            import ./nix/test-tailscale.nix {
+              tribuchet = self.packages.x86_64-linux.default;
+              nixosModule = self.nixosModules.default;
+            }
+          );
+
           # Evaluation-only check of the darwin module (the launchd plist
           # and activation script); building a darwin system needs a mac.
           darwin-module =

--- a/nix/test-tailscale.nix
+++ b/nix/test-tailscale.nix
@@ -1,0 +1,192 @@
+# NixOS VM test for `auth = "tailscale"`: a headscale control plane
+# brings hub and worker onto a tailnet, the hub runs without TLS and
+# resolves the peer via tailscaled's LocalAPI whois, and a build goes
+# through end to end. The worker registers under a tailscale hostname
+# distinct from its machine hostname, so the test would fail if the
+# hub used the self-reported name instead of the whois-asserted one.
+{ tribuchet, nixosModule }:
+{ pkgs, lib, ... }:
+let
+  stunPort = 3478;
+  hsPort = 8080;
+  tlsCert = pkgs.runCommand "headscale-cert" { nativeBuildInputs = [ pkgs.openssl ]; } ''
+    openssl req -x509 -newkey rsa:2048 -sha256 -days 365 -nodes \
+      -out cert.pem -keyout key.pem \
+      -subj '/CN=hub' -addext 'subjectAltName=DNS:hub'
+    mkdir $out && cp cert.pem key.pem $out
+  '';
+in
+{
+  name = "tribuchet-tailscale";
+  defaults.documentation.enable = false;
+
+  nodes = {
+    hub =
+      { pkgs, ... }:
+      {
+        imports = [ nixosModule ];
+
+        # headscale + DERP colocated with the hub keeps the test at two VMs.
+        services.headscale = {
+          enable = true;
+          port = hsPort;
+          settings = {
+            server_url = "https://hub";
+            ip_prefixes = [ "100.64.0.0/10" ];
+            derp = {
+              server = {
+                enabled = true;
+                region_id = 999;
+                stun_listen_addr = "0.0.0.0:${toString stunPort}";
+              };
+              urls = [ ];
+            };
+            dns = {
+              base_domain = "tailnet";
+              override_local_dns = false;
+            };
+          };
+        };
+        services.nginx = {
+          enable = true;
+          virtualHosts.hub = {
+            addSSL = true;
+            sslCertificate = "${tlsCert}/cert.pem";
+            sslCertificateKey = "${tlsCert}/key.pem";
+            locations."/" = {
+              proxyPass = "http://127.0.0.1:${toString hsPort}";
+              proxyWebsockets = true;
+            };
+          };
+        };
+        services.tailscale.enable = true;
+        security.pki.certificateFiles = [ "${tlsCert}/cert.pem" ];
+        networking.firewall = {
+          allowedTCPPorts = [
+            80
+            443
+            7437
+          ];
+          allowedUDPPorts = [ stunPort ];
+        };
+
+        virtualisation.memorySize = 2048;
+        virtualisation.writableStore = true;
+        virtualisation.additionalPaths = [ pkgs.bash ];
+        nix.settings.substituters = lib.mkForce [ ];
+
+        environment.systemPackages = [ pkgs.headscale ];
+
+        services.tribuchet-hub = {
+          enable = true;
+          package = tribuchet;
+          settings = {
+            auth = "tailscale";
+            worker-grace-secs = 2;
+          };
+          externalBuilders = {
+            enable = true;
+            systems = [ "x86_64-linux" ];
+          };
+        };
+        # started by the test script once tailscale is up
+        systemd.sockets.tribuchet-hub.wantedBy = lib.mkForce [ ];
+        systemd.services.tribuchet-hub.wantedBy = lib.mkForce [ ];
+      };
+
+    worker =
+      { pkgs, ... }:
+      {
+        imports = [ nixosModule ];
+
+        services.tailscale.enable = true;
+        security.pki.certificateFiles = [ "${tlsCert}/cert.pem" ];
+
+        virtualisation.memorySize = 2048;
+        virtualisation.useNixStoreImage = true;
+        virtualisation.writableStore = true;
+
+        services.tribuchet-worker = {
+          enable = true;
+          package = tribuchet;
+          settings = {
+            # placeholder; the test script substitutes the hub's
+            # tailnet IP so the connection arrives from a tailnet
+            # address (whois only knows those)
+            hub = "http://HUB_TS_IP:7437";
+            auth = "tailscale";
+            max-jobs = 1;
+          };
+        };
+        systemd.services.tribuchet-worker.wantedBy = lib.mkForce [ ];
+      };
+  };
+
+  testScript = ''
+    start_all()
+    hub.wait_for_unit("headscale")
+    hub.wait_for_open_port(443)
+    hub.wait_for_unit("tailscaled")
+    worker.wait_for_unit("tailscaled")
+
+    hub.succeed("headscale users create test")
+    authkey = hub.succeed("headscale preauthkeys -u 1 create --reusable").strip()
+
+    hub.succeed(
+        f"tailscale up --login-server https://hub --auth-key {authkey} --hostname hub"
+    )
+    # A distinct tailscale hostname proves the hub takes the
+    # whois-derived name, not the worker's self-reported hostname().
+    worker.succeed(
+        f"tailscale up --login-server https://hub --auth-key {authkey} --hostname tt-worker"
+    )
+    worker.wait_until_succeeds("tailscale ping hub", timeout=60)
+
+    hub_ts_ip = hub.succeed("tailscale ip -4").strip()
+    worker.succeed(
+        "cp --remove-destination "
+        "$(readlink -f /etc/tribuchet/worker.toml) /etc/tribuchet/worker.toml"
+        f" && sed -i 's/HUB_TS_IP/{hub_ts_ip}/' /etc/tribuchet/worker.toml"
+    )
+
+    hub.succeed("systemctl start tribuchet-hub.socket tribuchet-hub")
+    worker.succeed("systemctl start tribuchet-worker")
+    hub.wait_until_succeeds(
+        "journalctl -u tribuchet-hub | grep -q 'worker registered worker=\"tt-worker\"'",
+        timeout=60,
+    )
+
+    with subtest("a build dispatches over the tailnet"):
+        hub.succeed("echo tailscale-auth-payload > /root/payload")
+        unique = hub.succeed("nix-store --add /root/payload").strip()
+        hub.succeed(
+            "cat > /root/test.nix << 'EOF'\n"
+            "let\n"
+            '  bash = builtins.storePath "${pkgs.bash}";\n'
+            f'  unique = builtins.storePath "{unique}";\n'
+            "in derivation {\n"
+            '  name = "tt-tailscale";\n'
+            '  system = "x86_64-linux";\n'
+            '  builder = bash + "/bin/bash";\n'
+            '  args = [ "-c" ("read l < " + unique + "; echo \\"$l ok\\" > $out") ];\n'
+            "}\n"
+            "EOF"
+        )
+        out = hub.succeed("nix-build /root/test.nix --no-out-link").strip()
+        hub.succeed(f"grep -q 'tailscale-auth-payload ok' {out}")
+        hub.succeed("journalctl -u tribuchet-hub | grep -q 'dispatching build'")
+        worker.succeed("journalctl -u tribuchet-worker | grep -q 'builder finished'")
+
+    with subtest("a non-tailnet peer is rejected"):
+        # Dial the hub over the plain VM network: whois has no entry
+        # for that source address, so the session must be refused.
+        worker.succeed(
+            "sed -i 's|http://.*:7437|http://hub:7437|' /etc/tribuchet/worker.toml"
+        )
+        worker.succeed("systemctl restart tribuchet-worker")
+        hub.wait_until_succeeds(
+            "journalctl -u tribuchet-hub | grep -q 'tailscale whois failed'",
+            timeout=30,
+        )
+  '';
+}


### PR DESCRIPTION
With auth = "tailscale" the worker listener runs without TLS and the hub resolves each peer against tailscaled's LocalAPI whois: WireGuard provides confidentiality/integrity, the tailnet provides identity, and optionally tailscale-allowed-tags gates which ACL tags may register. The whois-asserted node name replaces the worker's self-reported one so a tailnet peer cannot impersonate another in logs/metrics.

A new headscale-based NixOS test brings hub and worker onto a tailnet, asserts the hub registers the worker under its tailscale hostname (not the VM hostname), runs a build end to end, and checks that a connection from a non-tailnet address is refused.