### PR TITLE
fix(tailscale): speak HTTP/1.0 to LocalAPI and percent-encode addr

### DIFF
--- a/.github/scripts/e2e/fetch-artifact.sh
+++ b/.github/scripts/e2e/fetch-artifact.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Poll for a sibling job's artifact in the same workflow run.
+# Usage: fetch-artifact.sh <artifact-name> <dest-dir>
+set -euo pipefail
+
+name=$1
+dest=$2
+for _ in $(seq 1 120); do
+  if gh run download "${GITHUB_RUN_ID}" -n "${name}" -D "${dest}" 2>/dev/null; then
+    exit 0
+  fi
+  sleep 5
+done
+echo "artifact ${name} did not appear" >&2
+exit 1

--- a/.github/scripts/e2e/hub-build.sh
+++ b/.github/scripts/e2e/hub-build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Wait for a worker to register, then run a unique derivation through
+# external-builders and assert it was dispatched.
+set -euxo pipefail
+
+for _ in $(seq 1 180); do
+  grep -q 'worker registered' hub.log && break
+  sleep 2
+done
+grep -q 'worker registered' hub.log || {
+  cat hub.log
+  exit 1
+}
+
+out=$(nix-build --no-out-link \
+  -I nixpkgs="$(nix eval --raw nixpkgs#path)" \
+  --argstr runId "${GITHUB_RUN_ID}" \
+  .github/scripts/e2e/probe.nix)
+grep -q built-on-worker-via-tailnet "${out}"
+grep -q 'dispatching build' hub.log
+touch ./done

--- a/.github/scripts/e2e/hub-start.sh
+++ b/.github/scripts/e2e/hub-start.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Configure nix-daemon for external-builders, start `tribuchet hub` in
+# tailscale-auth mode, and write the hub's tailnet IPv4 to addr.txt for
+# the worker job to download.
+set -euxo pipefail
+
+bin=$PWD/result/bin/tribuchet
+
+sudo mkdir -p /etc/tribuchet /run/tribuchet
+
+# auth=tailscale: no TLS material; identity via tailscaled whois.
+# Restrict to tag:ci so only this workflow's runners can register.
+sudo tee /etc/tribuchet/hub.toml >/dev/null <<'EOF'
+auth = "tailscale"
+listen = "0.0.0.0:7437"
+socket = "/run/tribuchet/hub.sock"
+config-dir = "/etc/tribuchet"
+worker-grace-secs = 90
+tailscale-allowed-tags = ["tag:ci"]
+EOF
+
+# nix-daemon execs this for every external build.
+sudo tee /usr/local/bin/tribuchet-attach >/dev/null <<EOF
+#!/bin/sh
+exec ${bin} attach "\$1" --socket /run/tribuchet/hub.sock
+EOF
+sudo chmod +x /usr/local/bin/tribuchet-attach
+
+# Route x86_64-linux builds through tribuchet.
+sudo tee -a /etc/nix/nix.conf >/dev/null <<'EOF'
+extra-experimental-features = external-builders
+external-builders = [{"systems":["x86_64-linux"],"program":"/usr/local/bin/tribuchet-attach"}]
+EOF
+sudo systemctl restart nix-daemon
+
+# Hub binds the attach socket to group nixbld; needs root for that and
+# for reading topTmpDir owned by build users. The redirect runs as the
+# unprivileged runner user on purpose so later steps can read the log.
+# shellcheck disable=SC2024
+sudo RUST_LOG=info "${bin}" hub --config /etc/tribuchet/hub.toml >hub.log 2>&1 &
+echo $! >hub.pid
+for _ in $(seq 1 30); do
+  grep -q 'hub running' hub.log && break
+  kill -0 "$(cat hub.pid)" 2>/dev/null || break
+  sleep 1
+done
+grep -q 'hub running' hub.log || {
+  cat hub.log
+  exit 1
+}
+
+tailscale ip -4 >addr.txt
+cat addr.txt hub.log

--- a/.github/scripts/e2e/probe.nix
+++ b/.github/scripts/e2e/probe.nix
@@ -1,0 +1,18 @@
+# Trivial derivation the e2e workflow builds through tribuchet.
+# `runId` makes the output uncacheable so it always reaches the worker.
+{
+  runId,
+  pkgs ? import <nixpkgs> { },
+}:
+derivation {
+  name = "tribuchet-e2e-${runId}";
+  system = "x86_64-linux";
+  # A store-path builder gives the derivation an input closure that
+  # tribuchet must ship to the worker; /bin/sh would not exist in the
+  # sandbox.
+  builder = "${pkgs.bash}/bin/bash";
+  args = [
+    "-c"
+    "echo built-on-worker-via-tailnet > $out"
+  ];
+}

--- a/.github/scripts/e2e/worker-run.sh
+++ b/.github/scripts/e2e/worker-run.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Start `tribuchet worker` against the hub's tailnet IP and keep it
+# alive until the hub job has uploaded its `done` artifact.
+set -euxo pipefail
+
+: "${HUB_TS_IP:?}"
+bin=$PWD/result/bin/tribuchet
+done_artifact="hub-done-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+sudo mkdir -p /etc/tribuchet /var/lib/tribuchet
+sudo tee /etc/tribuchet/worker.toml >/dev/null <<EOF
+hub = "http://${HUB_TS_IP}:7437"
+auth = "tailscale"
+max-jobs = 1
+state-dir = "/var/lib/tribuchet"
+EOF
+
+# Root for the Linux sandbox (mount/user namespaces) and for importing
+# inputs through nix-daemon as a trusted user. Redirect stays
+# unprivileged so later steps can read the log.
+# shellcheck disable=SC2024
+sudo RUST_LOG=info "${bin}" worker --config /etc/tribuchet/worker.toml >worker.log 2>&1 &
+echo $! >worker.pid
+
+for _ in $(seq 1 180); do
+  kill -0 "$(cat worker.pid)" 2>/dev/null || {
+    cat worker.log
+    exit 1
+  }
+  if gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" \
+    -q '.artifacts[].name' 2>/dev/null | grep -qx "${done_artifact}"; then
+    break
+  fi
+  sleep 5
+done
+
+grep -q 'builder finished' worker.log

--- a/.github/workflows/e2e-tailscale.yml
+++ b/.github/workflows/e2e-tailscale.yml
@@ -1,0 +1,112 @@
+name: e2e-tailscale
+
+# Runs after buildbot has pushed this commit's outputs to
+# cache.thalheim.io, so `nix build` below is a fetch, not a rebuild.
+on:
+  status:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+env:
+  NIX_EXTRA_CONF: |
+    extra-substituters = https://cache.thalheim.io
+    extra-trusted-public-keys = cache.thalheim.io-1:R7msbosLEZKrxk/lKxf9BTjOOH7Ax3H0Qj0/6wiHOgc=
+
+jobs:
+  # The status event fires for every commit status; only act on
+  # buildbot's final success, and only when the tailscale secrets are
+  # configured (forks / repos without them are skipped, not failed).
+  # `secrets` is not usable in a job-level `if`, hence the indirection.
+  gate:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.context == 'buildbot/nix-build' && github.event.state == 'success')
+    runs-on: ubuntu-latest
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has }}
+    steps:
+      - id: check
+        env:
+          TS: ${{ secrets.TS_OAUTH_SECRET }}
+        run: echo "has=$([ -n "$TS" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+  hub:
+    needs: gate
+    if: needs.gate.outputs.has-secrets == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.sha || github.sha }}
+
+      - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc
+        with:
+          extra-conf: ${{ env.NIX_EXTRA_CONF }}
+
+      - uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          hostname: tribuchet-hub-${{ github.run_id }}
+
+      - run: nix build .#default
+
+      - run: .github/scripts/e2e/hub-start.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: hub-addr-${{ github.run_id }}-${{ github.run_attempt }}
+          path: addr.txt
+          retention-days: 1
+
+      - run: .github/scripts/e2e/hub-build.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: hub-done-${{ github.run_id }}-${{ github.run_attempt }}
+          path: done
+          retention-days: 1
+
+      - if: always()
+        run: cat hub.log || true
+
+  worker:
+    needs: gate
+    if: needs.gate.outputs.has-secrets == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.sha || github.sha }}
+
+      - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc
+        with:
+          extra-conf: ${{ env.NIX_EXTRA_CONF }}
+
+      - uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          hostname: tribuchet-worker-${{ github.run_id }}
+
+      - run: nix build .#default
+
+      - name: fetch hub address
+        run: |
+          .github/scripts/e2e/fetch-artifact.sh \
+            "hub-addr-${{ github.run_id }}-${{ github.run_attempt }}" addr
+          echo "HUB_TS_IP=$(cat addr/addr.txt)" >> "$GITHUB_ENV"
+
+      - run: .github/scripts/e2e/worker-run.sh
+
+      - if: always()
+        run: cat worker.log || true

--- a/crates/tribuchet/src/hub.rs
+++ b/crates/tribuchet/src/hub.rs
@@ -460,7 +460,7 @@ fn load_trusted_keys(config_dir: &Path) -> Result<Option<Arc<Vec<PublicKey>>>> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             tracing::warn!(
                 "no trusted-signing-keys file in {}; accepting any signing key from \
-                 mTLS-authenticated workers",
+                 transport-authenticated workers",
                 config_dir.display()
             );
             Ok(None)

--- a/crates/tribuchet/src/tailscale.rs
+++ b/crates/tribuchet/src/tailscale.rs
@@ -47,11 +47,14 @@ pub async fn whois(socket: &Path, addr: SocketAddr) -> Result<WhoIs> {
         .with_context(|| format!("connecting to tailscaled at {}", socket.display()))?;
     // Host header is a fixed sentinel the daemon expects; the path
     // takes the full ip:port so tailscaled can match the exact
-    // 4-tuple it NATed.
+    // 4-tuple it NATed. The Go client percent-encodes the addr; do
+    // the same so an IPv6 `[::1]:p` is a valid query value.
+    // HTTP/1.0 so tailscaled cannot reply with Transfer-Encoding:
+    // chunked, which keeps the body parser below trivial.
     let req = format!(
-        "GET /localapi/v0/whois?addr={addr} HTTP/1.1\r\n\
-         Host: local-tailscaled.sock\r\n\
-         Connection: close\r\n\r\n"
+        "GET /localapi/v0/whois?addr={} HTTP/1.0\r\n\
+         Host: local-tailscaled.sock\r\n\r\n",
+        encode_addr(addr),
     );
     s.write_all(req.as_bytes()).await?;
     let mut buf = Vec::new();
@@ -71,9 +74,24 @@ pub async fn whois(socket: &Path, addr: SocketAddr) -> Result<WhoIs> {
     })
 }
 
-/// Split status line / headers from body and check for 200. Supports
-/// the `Connection: close` framing we asked for; tailscaled does not
-/// chunk these tiny responses.
+/// Minimal percent-encoding for the characters `SocketAddr` can emit
+/// that are reserved in a URI query (`[` `]` `:`).
+fn encode_addr(addr: SocketAddr) -> String {
+    let mut out = String::new();
+    for b in addr.to_string().bytes() {
+        match b {
+            b'[' => out.push_str("%5B"),
+            b']' => out.push_str("%5D"),
+            b':' => out.push_str("%3A"),
+            _ => out.push(b as char),
+        }
+    }
+    out
+}
+
+/// Split status line / headers from body and check for 200. The
+/// request is HTTP/1.0, so the body is delimited by connection close
+/// and never chunked.
 fn http_body(buf: &[u8]) -> Result<&[u8]> {
     let sep = buf
         .windows(4)
@@ -93,13 +111,19 @@ mod tests {
 
     #[test]
     fn parses_whois_body() {
-        let raw = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n\
+        let raw = b"HTTP/1.0 200 OK\r\nContent-Type: application/json\r\n\r\n\
             {\"Node\":{\"Name\":\"worker-1.tailnet.ts.net.\",\"Tags\":[\"tag:ci\"]},\
              \"UserProfile\":{}}";
         let body = http_body(raw).unwrap();
         let r: Resp = serde_json::from_slice(body).unwrap();
         assert_eq!(r.node.name, "worker-1.tailnet.ts.net.");
         assert_eq!(r.node.tags, vec!["tag:ci"]);
+    }
+
+    #[test]
+    fn ipv6_addr_is_encoded() {
+        let a: SocketAddr = "[fd7a:115c::1]:1234".parse().unwrap();
+        assert_eq!(encode_addr(a), "%5Bfd7a%3A115c%3A%3A1%5D%3A1234");
     }
 
     #[test]


### PR DESCRIPTION
tailscaled may answer the whois request with Transfer-Encoding:
chunked over HTTP/1.1; the trivial body splitter then tries to parse
the chunk-size line as JSON and every worker session is rejected as
"not on the tailnet".  Downgrading the request to HTTP/1.0 forbids
chunking, so the body is always delimited by connection close.

Also percent-encode [, ] and : in the addr query value so an IPv6
peer ("[fd7a::1]:p") is a valid URI, matching the Go LocalAPI client,
and drop the mTLS-specific wording from the trusted-signing-keys
warning.
