### PR TITLE
ci(e2e-tailscale): only run on default-branch commits

### DIFF
--- a/.github/workflows/e2e-tailscale.yml
+++ b/.github/workflows/e2e-tailscale.yml
@@ -17,13 +17,18 @@ env:
 
 jobs:
   # The status event fires for every commit status; only act on
-  # buildbot's final success, and only when the tailscale secrets are
-  # configured (forks / repos without them are skipped, not failed).
-  # `secrets` is not usable in a job-level `if`, hence the indirection.
+  # buildbot's final success on the default branch. status payloads list
+  # only branches in *this* repo, so a fork-PR head has an empty
+  # `branches` and is skipped — otherwise its checked-out flake and
+  # scripts would run with tailnet access. Also skip when the tailscale
+  # secrets are not configured. `secrets` is not usable in a job-level
+  # `if`, hence the indirection.
   gate:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.context == 'buildbot/nix-build' && github.event.state == 'success')
+      (github.event.context == 'buildbot/nix-build'
+       && github.event.state == 'success'
+       && contains(github.event.branches.*.name, github.event.repository.default_branch))
     runs-on: ubuntu-latest
     outputs:
       has-secrets: ${{ steps.check.outputs.has }}


### PR DESCRIPTION
on: status fires for any commit buildbot reports on, including fork-PR
heads.  We then check out that sha and run its flake and e2e scripts
with the runner already on the tailnet (tag:ci) and the built binary
under sudo, so a fork PR that passes buildbot would get arbitrary code
on a tailnet-joined runner.  status payloads only list branches in this
repo, so gating on the default branch being among them excludes
fork-PR heads (and feature branches) without losing post-merge
coverage.
