### PR TITLE
ci(e2e-tailscale): run on own-repo branch PRs too

### DIFF
--- a/.github/workflows/e2e-tailscale.yml
+++ b/.github/workflows/e2e-tailscale.yml
@@ -31,18 +31,19 @@ env:
 
 jobs:
   # The status event fires for every commit status; only act on
-  # buildbot's final success on the default branch. status payloads list
-  # only branches in *this* repo, so a fork-PR head has an empty
-  # `branches` and is skipped — otherwise its checked-out flake and
-  # scripts would run with tailnet access. Also skip when the tailscale
-  # secrets are not configured. `secrets` is not usable in a job-level
-  # `if`, hence the indirection.
+  # buildbot's final success on a commit that lives on a branch in
+  # *this* repo. status payloads list only such branches, so a fork-PR
+  # head has an empty `branches` and is skipped — otherwise its
+  # checked-out flake and scripts would run with tailnet access. Own
+  # branch PRs (push access ⇒ trusted) do run. Also skip when the
+  # tailscale secrets are not configured. `secrets` is not usable in a
+  # job-level `if`, hence the indirection.
   gate:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.context == 'buildbot/nix-build'
        && github.event.state == 'success'
-       && contains(github.event.branches.*.name, github.event.repository.default_branch))
+       && github.event.branches[0] != null)
     runs-on: ubuntu-latest
     outputs:
       has-secrets: ${{ steps.check.outputs.has }}


### PR DESCRIPTION
Gate on "commit is on some branch in this repo" instead of "on the
default branch".  status payloads only list branches that exist here,
so fork-PR heads still have an empty branches array and stay excluded;
branches pushed by collaborators (who already have write access) now
get the e2e run on their PRs.
