### PR TITLE
ci(e2e-tailscale): cancel superseded runs per branch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,12 @@ on:
     types: [completed]
   workflow_dispatch:
 
+# A force-push (or nixbot re-run) fires a fresh check_run for the same
+# branch; cancel the superseded e2e instead of running both.
+concurrency:
+  group: e2e-${{ github.event.check_run.check_suite.head_branch || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   actions: read
   contents: read


### PR DESCRIPTION
Every force-push (and every nixbot re-run) emits a fresh check_run, so
the same PR could have several e2e runs in flight.  Key the
concurrency group on the check_run's head_branch and cancel the older
one.
