### PR TITLE
ci: rename e2e-tailscale workflow to e2e

### DIFF
--- a/.github/scripts/e2e/run.py
+++ b/.github/scripts/e2e/run.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Drive the two-runner e2e-tailscale workflow.
+"""Drive the two-runner e2e workflow.
 
 One script with subcommands keeps the orchestration in one place and
 out of the YAML; the workflow steps just call ``run.py <cmd>``.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,5 @@
-name: e2e-tailscale
-run-name: e2e-tailscale @ ${{ github.event.check_run.head_sha || github.sha }}
+name: e2e
+run-name: e2e @ ${{ github.event.check_run.head_sha || github.sha }}
 
 # Two GitHub-hosted runners join the same tailnet, one runs
 # `tribuchet hub` with auth="tailscale", the other runs the worker, and
@@ -63,7 +63,7 @@ jobs:
           SHA: ${{ github.event.check_run.head_sha || github.sha }}
         run: |
           gh api "repos/${{ github.repository }}/statuses/$SHA" \
-            -f state=pending -f context=e2e-tailscale \
+            -f state=pending -f context=e2e \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   hub:
@@ -155,5 +155,5 @@ jobs:
           STATE: ${{ (needs.hub.result == 'success' && needs.worker.result == 'success') && 'success' || 'failure' }}
         run: |
           gh api "repos/${{ github.repository }}/statuses/$SHA" \
-            -f state="$STATE" -f context=e2e-tailscale \
+            -f state="$STATE" -f context=e2e \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
Tailscale is how the two runners reach each other, not what the test
is about; the status context that shows up on PRs should just say
e2e.
