### PR TITLE
ci(e2e): add aarch64-linux and aarch64-darwin worker matrix

### DIFF
--- a/.github/scripts/e2e/probe.nix
+++ b/.github/scripts/e2e/probe.nix
@@ -1,18 +1,26 @@
-# Trivial derivation the e2e workflow builds through tribuchet.
-# `runId` makes the output uncacheable so it always reaches the worker.
+# Trivial per-system derivations the e2e workflow builds through
+# tribuchet. `runId` makes the outputs uncacheable so each one always
+# reaches its worker.
 {
   runId,
-  pkgs ? import <nixpkgs> { },
+  systems,
+  nixpkgs ? <nixpkgs>,
 }:
-derivation {
-  name = "tribuchet-e2e-${runId}";
-  system = "x86_64-linux";
-  # A store-path builder gives the derivation an input closure that
-  # tribuchet must ship to the worker; /bin/sh would not exist in the
-  # sandbox.
-  builder = "${pkgs.bash}/bin/bash";
-  args = [
-    "-c"
-    "echo built-on-worker-via-tailnet > $out"
-  ];
-}
+let
+  one = system: {
+    name = system;
+    value = derivation {
+      name = "tribuchet-e2e-${system}-${runId}";
+      inherit system;
+      # A store-path builder gives the derivation an input closure that
+      # tribuchet must ship to the worker; /bin/sh would not exist in
+      # the Linux sandbox.
+      builder = "${(import nixpkgs { inherit system; }).bash}/bin/bash";
+      args = [
+        "-c"
+        "echo built-on-${system}-via-tailnet > $out"
+      ];
+    };
+  };
+in
+builtins.listToAttrs (map one systems)

--- a/.github/scripts/e2e/run.py
+++ b/.github/scripts/e2e/run.py
@@ -76,11 +76,13 @@ def spawn_daemon(argv: list[str], log: Path) -> subprocess.Popen[bytes]:
 # ---------------------------------------------------------------- hub ----
 
 
-def hub_start() -> None:
+def hub_start(systems: list[str]) -> None:
     run(["sudo", "mkdir", "-p", "/etc/tribuchet", "/run/tribuchet"])
 
     # auth=tailscale: no TLS material; identity via tailscaled whois.
     # Restrict to tag:ci so only this workflow's runners can register.
+    # worker-grace-secs covers the slowest matrix worker (macOS install
+    # + cold cache) so per-system builds wait instead of declining.
     sudo_write(
         "/etc/tribuchet/hub.toml",
         textwrap.dedent(
@@ -89,7 +91,7 @@ def hub_start() -> None:
             listen = "0.0.0.0:7437"
             socket = "/run/tribuchet/hub.sock"
             config-dir = "/etc/tribuchet"
-            worker-grace-secs = 90
+            worker-grace-secs = 600
             tailscale-allowed-tags = ["tag:ci"]
             """
         ),
@@ -103,12 +105,11 @@ def hub_start() -> None:
     )
     run(["sudo", "chmod", "+x", "/usr/local/bin/tribuchet-attach"])
 
-    # Route x86_64-linux builds through tribuchet. `args` is required by
-    # the external-builders schema even when empty.
+    # `args` is required by the external-builders schema even when empty.
     eb = json.dumps(
         [
             {
-                "systems": ["x86_64-linux"],
+                "systems": systems,
                 "program": "/usr/local/bin/tribuchet-attach",
                 "args": [],
             }
@@ -147,7 +148,7 @@ def hub_start() -> None:
     print(HUB_LOG.read_text())
 
 
-def hub_build() -> None:
+def hub_build(systems: list[str]) -> None:
     wait_for(
         lambda: log_contains(HUB_LOG, "worker registered"),
         timeout=360,
@@ -156,23 +157,34 @@ def hub_build() -> None:
     )
 
     nixpkgs = out(["nix", "eval", "--raw", "nixpkgs#path"])
-    result = out(
+    # One nix-build for all systems: the hub queues each derivation and
+    # dispatches it once the matching worker registers (within
+    # worker-grace-secs), so per-system arrival order does not matter.
+    results = out(
         [
             "nix-build",
             "--no-out-link",
+            "--max-jobs",
+            str(len(systems)),
             "-I",
             f"nixpkgs={nixpkgs}",
             "--argstr",
             "runId",
             os.environ["GITHUB_RUN_ID"],
+            "--arg",
+            "systems",
+            "[ " + " ".join(f'"{s}"' for s in systems) + " ]",
             str(REPO / ".github/scripts/e2e/probe.nix"),
         ]
-    )
-    payload = Path(result).read_text()
-    if "built-on-worker-via-tailnet" not in payload:
-        raise SystemExit(f"unexpected build output: {payload!r}")
+    ).splitlines()
+    if len(results) != len(systems):
+        raise SystemExit(f"expected {len(systems)} outputs, got {results!r}")
+    for path in results:
+        payload = Path(path).read_text().strip()
+        if not payload.endswith("-via-tailnet"):
+            raise SystemExit(f"unexpected build output in {path}: {payload!r}")
     if not log_contains(HUB_LOG, "dispatching build"):
-        raise SystemExit("hub never dispatched the build")
+        raise SystemExit("hub never dispatched a build")
     (REPO / "done").touch()
 
 
@@ -261,8 +273,10 @@ def worker_run(hub_ip: str) -> None:
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     sub = ap.add_subparsers(dest="cmd", required=True)
-    sub.add_parser("hub-start")
-    sub.add_parser("hub-build")
+    p = sub.add_parser("hub-start")
+    p.add_argument("--systems", nargs="+", required=True)
+    p = sub.add_parser("hub-build")
+    p.add_argument("--systems", nargs="+", required=True)
     p = sub.add_parser("worker")
     p.add_argument("--hub-ip", required=True)
     p = sub.add_parser("fetch-artifact")
@@ -272,9 +286,9 @@ def main() -> None:
 
     match args.cmd:
         case "hub-start":
-            hub_start()
+            hub_start(args.systems)
         case "hub-build":
-            hub_build()
+            hub_build(args.systems)
         case "worker":
             worker_run(args.hub_ip)
         case "fetch-artifact":

--- a/.github/scripts/e2e/run.py
+++ b/.github/scripts/e2e/run.py
@@ -17,6 +17,7 @@ import time
 import urllib.request
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 REPO = Path(__file__).resolve().parents[3]
 BIN = REPO / "result" / "bin" / "tribuchet"
@@ -185,7 +186,6 @@ def hub_build(systems: list[str]) -> None:
             raise SystemExit(f"unexpected build output in {path}: {payload!r}")
     if not log_contains(HUB_LOG, "dispatching build"):
         raise SystemExit("hub never dispatched a build")
-    (REPO / "done").touch()
 
 
 # ------------------------------------------------------------- worker ----
@@ -205,12 +205,11 @@ def fetch_artifact(name: str, dest: str) -> None:
     wait_for(attempt, timeout=600, interval=5, what=f"artifact {name}")
 
 
-def artifact_exists(name: str) -> bool:
-    """Cheaper than `gh run download` for a presence poll."""
-    repo = os.environ["GITHUB_REPOSITORY"]
-    run_id = os.environ["GITHUB_RUN_ID"]
+def gh_api(path: str) -> Any | None:
+    """GET the GitHub REST API; ``None`` on transient errors so callers
+    inside a poll loop treat them as "not yet"."""
     req = urllib.request.Request(
-        f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/artifacts",
+        f"https://api.github.com/repos/{os.environ['GITHUB_REPOSITORY']}/{path}",
         headers={
             "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
             "Accept": "application/vnd.github+json",
@@ -218,11 +217,22 @@ def artifact_exists(name: str) -> bool:
     )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
-            data = json.load(r)
+            return json.load(r)
     except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
-        # Transient API errors are "not yet"; the wait loop keeps polling.
-        return False
-    return any(a["name"] == name for a in data.get("artifacts", []))
+        return None
+
+
+def job_conclusion(name: str) -> str | None:
+    """Conclusion of a sibling job in this run, or ``None`` while it is
+    still running / on transient API errors."""
+    data = gh_api(f"actions/runs/{os.environ['GITHUB_RUN_ID']}/jobs")
+    if data is None:
+        return None
+    for j in data.get("jobs", []):
+        if j["name"] == name:
+            c: str | None = j.get("conclusion")
+            return c
+    return None
 
 
 def worker_run(hub_ip: str) -> None:
@@ -253,15 +263,18 @@ def worker_run(hub_ip: str) -> None:
         WORKER_LOG,
     )
 
-    run_id = os.environ["GITHUB_RUN_ID"]
-    attempt = os.environ["GITHUB_RUN_ATTEMPT"]
-    done = f"hub-done-{run_id}-{attempt}"
-    wait_for(
-        lambda: proc.poll() is not None or artifact_exists(done),
-        timeout=900,
-        interval=5,
-        what="hub to finish",
-    )
+    def finished() -> bool:
+        if proc.poll() is not None:
+            return True
+        c = job_conclusion("hub")
+        if c is None:
+            return False
+        if c != "success":
+            sys.stderr.write(WORKER_LOG.read_text())
+            raise SystemExit(f"hub job concluded {c!r}; aborting")
+        return True
+
+    wait_for(finished, timeout=900, interval=5, what="hub to finish")
     if not log_contains(WORKER_LOG, "builder finished"):
         sys.stderr.write(WORKER_LOG.read_text())
         raise SystemExit("worker never ran a build")

--- a/.github/workflows/e2e-tailscale.yml
+++ b/.github/workflows/e2e-tailscale.yml
@@ -34,6 +34,7 @@ env:
   NIX_EXTRA_CONF: |
     extra-substituters = https://cache.thalheim.io
     extra-trusted-public-keys = cache.thalheim.io-1:R7msbosLEZKrxk/lKxf9BTjOOH7Ax3H0Qj0/6wiHOgc=
+  E2E_SYSTEMS: x86_64-linux aarch64-linux aarch64-darwin
 
 jobs:
   # nixbot reports via the Checks API; only act on its final success.
@@ -70,7 +71,7 @@ jobs:
     needs: gate
     if: needs.gate.outputs.has-secrets == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
         with:
@@ -89,7 +90,7 @@ jobs:
 
       - run: nix build .#default
 
-      - run: python3 .github/scripts/e2e/run.py hub-start
+      - run: python3 .github/scripts/e2e/run.py hub-start --systems $E2E_SYSTEMS
 
       - uses: actions/upload-artifact@v4
         with:
@@ -97,7 +98,7 @@ jobs:
           path: addr.txt
           retention-days: 1
 
-      - run: python3 .github/scripts/e2e/run.py hub-build
+      - run: python3 .github/scripts/e2e/run.py hub-build --systems $E2E_SYSTEMS
 
       - uses: actions/upload-artifact@v4
         with:
@@ -111,7 +112,18 @@ jobs:
   worker:
     needs: gate
     if: needs.gate.outputs.has-secrets == 'true'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            system: x86_64-linux
+          - os: ubuntu-24.04-arm
+            system: aarch64-linux
+          - os: macos-latest
+            system: aarch64-darwin
+    runs-on: ${{ matrix.os }}
+    name: worker (${{ matrix.system }})
     timeout-minutes: 20
     env:
       GH_TOKEN: ${{ github.token }}
@@ -129,7 +141,7 @@ jobs:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci
-          hostname: tribuchet-worker-${{ github.run_id }}
+          hostname: tribuchet-worker-${{ matrix.system }}-${{ github.run_id }}
 
       - run: nix build .#default
 

--- a/.github/workflows/e2e-tailscale.yml
+++ b/.github/workflows/e2e-tailscale.yml
@@ -100,12 +100,6 @@ jobs:
 
       - run: python3 .github/scripts/e2e/run.py hub-build --systems $E2E_SYSTEMS
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: hub-done-${{ github.run_id }}-${{ github.run_attempt }}
-          path: done
-          retention-days: 1
-
       - if: always()
         run: cat hub.log || true
 


### PR DESCRIPTION
The hub now routes builds for all three systems through tribuchet and
fires one probe derivation per system; each blocks in the queue until
its worker registers (worker-grace-secs raised to cover a cold macOS
runner).  The worker job is a fail-fast=false matrix over
ubuntu-latest / ubuntu-24.04-arm / macos-latest.
