### PR TITLE
ci(e2e): sanitise tailscale worker hostname

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -118,10 +118,13 @@ jobs:
         include:
           - os: ubuntu-latest
             system: x86_64-linux
+            slug: x86-64-linux
           - os: ubuntu-24.04-arm
             system: aarch64-linux
+            slug: aarch64-linux
           - os: macos-latest
             system: aarch64-darwin
+            slug: aarch64-darwin
     runs-on: ${{ matrix.os }}
     name: worker (${{ matrix.system }})
     timeout-minutes: 20
@@ -141,7 +144,9 @@ jobs:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci
-          hostname: tribuchet-worker-${{ matrix.system }}-${{ github.run_id }}
+          # Tailscale hostnames are DNS labels; matrix.system can
+          # contain '_' (x86_64-linux), so use the sanitised slug.
+          hostname: tw-${{ matrix.slug }}-${{ github.run_id }}
 
       - run: nix build .#default
 


### PR DESCRIPTION
matrix.system contains an underscore (x86_64-linux), which is not a
valid DNS label, so the tailscale action refused to start.  Add a
slug per matrix entry and shorten the prefix so the label stays well
under 63 characters.
