### PR TITLE
ci(e2e): use the flake's locked nixpkgs for the probe builds

### DIFF
--- a/.github/scripts/e2e/run.py
+++ b/.github/scripts/e2e/run.py
@@ -157,7 +157,8 @@ def hub_build(systems: list[str]) -> None:
         what="a worker to register",
     )
 
-    nixpkgs = out(["nix", "eval", "--raw", "nixpkgs#path"])
+    # The flake-locked nixpkgs is what nixbot built and cached.
+    nixpkgs = out(["nix", "eval", "--raw", "--inputs-from", ".", "nixpkgs#path"])
     # One nix-build for all systems: the hub queues each derivation and
     # dispatches it once the matching worker registers (within
     # worker-grace-secs), so per-system arrival order does not matter.


### PR DESCRIPTION
`--inputs-from .` resolves `nixpkgs` to the flake-locked input instead of the floating registry pin, so the probe builds use what nixbot already built and cached.