### PR TITLE
fix(darwin): rewrite tmpDirInSandbox into the worker's build dir

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -107,10 +107,11 @@ Reference implementations: `nix/src/libstore/unix/build/` and
   unreachable, and root workers back such builds with an unprivileged
   uid.
 * macOS: no mount namespace, but inputs already live at their real
-  /nix/store paths thanks to the daemon import; the request's per-build
-  `tmpDirInSandbox` (a `/private/tmp/nix-build-*` path — Nix has no
-  `/build` on Darwin) becomes a symlink to the build dir, and the builder
-  runs under `/usr/bin/sandbox-exec` with a deny-default write profile
+  /nix/store paths thanks to the daemon import; the worker's own
+  per-build dir becomes the cwd and env values referencing the hub's
+  `tmpDirInSandbox` (e.g. `/build` from a Linux hub) are rewritten to
+  it, so no symlink is created at a hub-chosen path. The builder runs
+  under `/usr/bin/sandbox-exec` with a deny-default write profile
   modeled on Nix's `sandbox-defaults.sb` (reads stay permissive except
   for the worker's key material; writes are scoped to the build dir,
   outputs, and specific device nodes; signals are limited to the

--- a/crates/tribuchet/src/worker/sandbox.rs
+++ b/crates/tribuchet/src/worker/sandbox.rs
@@ -473,19 +473,18 @@ mod tests {
         Ok(())
     }
 
-    /// End-to-end smoke test of the Darwin sandbox: prepare's tmp-dir
-    /// symlink, writes confined to the build dir, deny_read on worker
-    /// secrets, and exit-code plumbing through sandbox-exec.
+    /// End-to-end smoke test of the Darwin sandbox: prepare's env
+    /// rewrite of the hub's tmpDirInSandbox to the local build dir,
+    /// writes confined to that dir, deny_read on worker secrets, and
+    /// exit-code plumbing through sandbox-exec.
     #[cfg(target_os = "macos")]
     #[test]
     fn sandbox_runs_builder() -> Result<()> {
-        // tempdir lives under $TMPDIR (/var/folders/...), one of the
-        // tmp prefixes prepare() accepts for the cwd symlink.
         let dir = tempfile::tempdir()?;
         let secret = dir.path().join("secret");
         fs::write(&secret, "key-material")?;
         let outside = dir.path().join("outside");
-        let cwd = dir.path().join("build-link");
+        let build_dir = dir.path().join("top/build");
         let mut spec = SandboxSpec {
             builder: "/bin/sh".into(),
             system: "aarch64-darwin".into(),
@@ -493,22 +492,32 @@ mod tests {
                 "-c".into(),
                 // Each escape attempt exits with its own code so a
                 // failure names the broken rule; 7 means all held.
-                // $FOO asserts the derivation env reaches the builder.
+                // $FOO: derivation env reaches the builder.
+                // $NIX_BUILD_TOP/$ATTRS: prepare() rewrote /build to
+                // the local build dir (Linux-hub cross-dispatch).
                 format!(
                     "test \"$FOO\" = bar || exit 1; \
+                     test \"$NIX_BUILD_TOP\" = \"{build_dir}\" || exit 5; \
+                     test \"$ATTRS\" = \"{build_dir}/.attrs.json\" || exit 6; \
                      echo ok > out || exit 2; \
                      cat {secret} 2>/dev/null && exit 3; \
                      echo escaped > {outside} 2>/dev/null && exit 4; \
                      exit 7",
                     secret = secret.display(),
-                    outside = outside.display()
+                    outside = outside.display(),
+                    build_dir = build_dir.display(),
                 ),
             ],
-            env: HashMap::from([("FOO".into(), "bar".into())]),
-            cwd: cwd.to_string_lossy().into_owned(),
+            env: HashMap::from([
+                ("FOO".into(), "bar".into()),
+                ("NIX_BUILD_TOP".into(), "/build".into()),
+                ("ATTRS".into(), "/build/.attrs.json".into()),
+            ]),
+            // What a Linux hub sends; prepare() must rewrite it.
+            cwd: "/build".into(),
             network: false,
             root: dir.path().join("root"),
-            build_dir: dir.path().join("top/build"),
+            build_dir,
             binds_ro: vec![],
             binds_dev: vec![],
             outputs: vec![],

--- a/crates/tribuchet/src/worker/sandbox/darwin.rs
+++ b/crates/tribuchet/src/worker/sandbox/darwin.rs
@@ -17,35 +17,25 @@ pub fn prepare(spec: &mut SandboxSpec) -> Result<()> {
     // /nix/store paths (the worker imports them via the daemon),
     // so there is nothing to materialize.
     spec.binds_ro.clear();
-    // env refers to tmpDirInSandbox; link it to the real build dir.
-    // Darwin daemons always send a per-build tmp path here (Nix has
-    // no /build on macOS), so each build gets its own symlink.
-    let link = Path::new(&spec.cwd);
-    // Don't trust the hub: a root worker creating a symlink at an
-    // arbitrary path is a takeover primitive. Allow only tmp prefixes.
-    let allowed = [
-        "/tmp/",
-        "/private/tmp/",
-        "/private/var/folders/",
-        "/var/folders/",
-    ]
-    .iter()
-    .any(|p| spec.cwd.starts_with(p));
-    if !allowed {
-        anyhow::bail!("refusing tmpDirInSandbox outside tmp: {}", spec.cwd);
-    }
-    match fs::symlink_metadata(link) {
-        Ok(meta) if meta.file_type().is_symlink() => {
-            fs::remove_file(link)?; // stale link from a crashed build
+    // No mount namespace on macOS: use the worker's own per-build dir
+    // as cwd and rewrite env values referencing the hub's
+    // tmpDirInSandbox (e.g. "/build" from a Linux hub). Avoids any
+    // symlink at a hub-chosen path on a root worker.
+    let from = std::mem::take(&mut spec.cwd);
+    let to = spec
+        .build_dir
+        .to_str()
+        .context("build dir is not valid UTF-8")?
+        .to_owned();
+    let prefix = format!("{from}/");
+    for v in spec.env.values_mut() {
+        if *v == from {
+            v.clone_from(&to);
+        } else if let Some(rest) = v.strip_prefix(&prefix) {
+            *v = format!("{to}/{rest}");
         }
-        Ok(_) => anyhow::bail!("tmpDirInSandbox {} already exists", spec.cwd),
-        Err(_) => {}
     }
-    if let Some(parent) = link.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    std::os::unix::fs::symlink(&spec.build_dir, link)
-        .with_context(|| format!("creating {} symlink", link.display()))?;
+    spec.cwd = to;
     Ok(())
 }
 
@@ -97,11 +87,7 @@ pub fn command(spec: &SandboxSpec) -> Result<Command> {
     // Like deny_read above: writes resolve to the canonical vnode
     // path, so a subpath on the literal alone (e.g. a build dir under
     // the /var -> /private/var symlink) would never match. Emit both.
-    let build_dir = spec.build_dir.to_string_lossy();
-    for path in std::iter::once(spec.cwd.as_str())
-        .chain(std::iter::once(build_dir.as_ref()))
-        .chain(spec.outputs.iter().map(String::as_str))
-    {
+    for path in std::iter::once(spec.cwd.as_str()).chain(spec.outputs.iter().map(String::as_str)) {
         writeln!(profile, "  (subpath \"{}\")", sb_escape(path)?)?;
         if let Ok(canonical) = Path::new(path).canonicalize() {
             let canonical = canonical.to_string_lossy();
@@ -153,19 +139,12 @@ pub fn send_spec(_child: &mut Child, _spec: &SandboxSpec) -> Result<()> {
     Ok(())
 }
 
-pub fn cleanup(a: &BuildAssignment, dir: &Path) {
+pub fn cleanup(a: &BuildAssignment, _dir: &Path) {
     // Outputs were written straight into /nix/store; drop them after
-    // upload, and remove the /build symlink.
+    // upload.
     for scratch in a.outputs.values() {
         let p = Path::new(scratch);
         let _ = fs::remove_dir_all(p);
         let _ = fs::remove_file(p);
-    }
-    // Only remove the symlink this build created (it points at our
-    // build dir): a hub-chosen path that prepare() rejected must not
-    // become a delete-anything primitive on a root worker.
-    let link = Path::new(&a.tmp_dir_in_sandbox);
-    if fs::read_link(link).is_ok_and(|t| t == dir.join("top").join("build")) {
-        let _ = fs::remove_file(link);
     }
 }


### PR DESCRIPTION
A Linux hub sends `tmpDirInSandbox = "/build"`; without a mount namespace the macOS worker tried to symlink that path, which the safety check refused. Set cwd to the worker-controlled build dir and prefix-rewrite env values that referenced the hub's path instead — enabling Linux-hub → macOS-worker dispatch and removing the root-symlink-at-hub-chosen-path primitive.

Found by the e2e workflow's `aarch64-darwin` worker leg.