### PR TITLE
test: cover DNS resolution in fixed-output build sandboxes

### DIFF
--- a/.github/scripts/e2e/probe-fod.nix
+++ b/.github/scripts/e2e/probe-fod.nix
@@ -1,0 +1,33 @@
+# Fixed-output probes: curl must resolve a hostname and complete a TLS
+# fetch from inside the sandbox (pasta's forwarder on Linux, seatbelt's
+# network* on macOS). runId keeps the store path uncached so the build
+# really runs on the worker; the output is constant for the fixed hash.
+{
+  runId,
+  systems,
+  nixpkgs ? <nixpkgs>,
+}:
+let
+  one = system: {
+    name = system;
+    value =
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      derivation {
+        name = "tribuchet-e2e-fod-${system}-${runId}";
+        inherit system;
+        builder = "${pkgs.bash}/bin/bash";
+        PATH = "${pkgs.curl}/bin";
+        args = [
+          "-c"
+          "curl -sSf https://example.com > /dev/null && echo fod-dns-ok > $out"
+        ];
+        outputHashAlgo = "sha256";
+        outputHashMode = "flat";
+        # sha256 of "fod-dns-ok\n"
+        outputHash = "sha256-LB7J/GiffOgGvs4AiiLQLQAZmwnM5dBnExXUtjgF0IA=";
+      };
+  };
+in
+builtins.listToAttrs (map one systems)

--- a/.github/scripts/e2e/run.py
+++ b/.github/scripts/e2e/run.py
@@ -159,32 +159,38 @@ def hub_build(systems: list[str]) -> None:
 
     # The flake-locked nixpkgs is what nixbot built and cached.
     nixpkgs = out(["nix", "eval", "--raw", "--inputs-from", ".", "nixpkgs#path"])
-    # One nix-build for all systems: the hub queues each derivation and
-    # dispatches it once the matching worker registers (within
-    # worker-grace-secs), so per-system arrival order does not matter.
-    results = out(
-        [
-            "nix-build",
-            "--no-out-link",
-            "--max-jobs",
-            str(len(systems)),
-            "-I",
-            f"nixpkgs={nixpkgs}",
-            "--argstr",
-            "runId",
-            os.environ["GITHUB_RUN_ID"],
-            "--arg",
-            "systems",
-            "[ " + " ".join(f'"{s}"' for s in systems) + " ]",
-            str(REPO / ".github/scripts/e2e/probe.nix"),
-        ]
-    ).splitlines()
-    if len(results) != len(systems):
-        raise SystemExit(f"expected {len(systems)} outputs, got {results!r}")
-    for path in results:
-        payload = Path(path).read_text().strip()
-        if not payload.endswith("-via-tailnet"):
-            raise SystemExit(f"unexpected build output in {path}: {payload!r}")
+
+    def build(probe: str, suffix: str) -> list[str]:
+        # One nix-build for all systems: the hub queues each derivation
+        # and dispatches it once the matching worker registers (within
+        # worker-grace-secs), so per-system arrival order does not matter.
+        paths = out(
+            [
+                "nix-build",
+                "--no-out-link",
+                "--max-jobs",
+                str(len(systems)),
+                "-I",
+                f"nixpkgs={nixpkgs}",
+                "--argstr",
+                "runId",
+                os.environ["GITHUB_RUN_ID"],
+                "--arg",
+                "systems",
+                "[ " + " ".join(f'"{s}"' for s in systems) + " ]",
+                str(REPO / ".github/scripts/e2e" / probe),
+            ]
+        ).splitlines()
+        if len(paths) != len(systems):
+            raise SystemExit(f"expected {len(systems)} outputs, got {paths!r}")
+        for path in paths:
+            payload = Path(path).read_text().strip()
+            if not payload.endswith(suffix):
+                raise SystemExit(f"unexpected build output in {path}: {payload!r}")
+        return paths
+
+    build("probe.nix", "-via-tailnet")
+    build("probe-fod.nix", "fod-dns-ok")  # DNS + TLS from inside the sandbox
     if not log_contains(HUB_LOG, "dispatching build"):
         raise SystemExit("hub never dispatched a build")
 

--- a/.github/scripts/e2e/run.py
+++ b/.github/scripts/e2e/run.py
@@ -229,6 +229,22 @@ def gh_api(path: str) -> Any | None:
         return None
 
 
+def wait_buildbot(sha: str) -> None:
+    """Block until the buildbot check run for *sha* succeeds, so the
+    build below fetches nixbot's closure instead of rebuilding. Tolerates
+    a not-yet-listed check (workflow_dispatch can precede buildbot)."""
+    name = "buildbot/nix-build"
+
+    def ready() -> bool:
+        data = gh_api(f"commits/{sha}/check-runs?check_name={name}")
+        if data is None:
+            return False
+        runs = data.get("check_runs", [])
+        return bool(runs) and all(r.get("conclusion") == "success" for r in runs)
+
+    wait_for(ready, timeout=1800, interval=15, what=f"{name} on {sha[:8]}")
+
+
 def job_conclusion(name: str) -> str | None:
     """Conclusion of a sibling job in this run, or ``None`` while it is
     still running / on transient API errors."""
@@ -302,6 +318,8 @@ def main() -> None:
     p = sub.add_parser("fetch-artifact")
     p.add_argument("name")
     p.add_argument("dest")
+    p = sub.add_parser("wait-buildbot")
+    p.add_argument("sha")
     args = ap.parse_args()
 
     match args.cmd:
@@ -313,6 +331,8 @@ def main() -> None:
             worker_run(args.hub_ip)
         case "fetch-artifact":
             fetch_artifact(args.name, args.dest)
+        case "wait-buildbot":
+            wait_buildbot(args.sha)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,20 @@
+# Auto-approve and merge dependency-update PRs (dependabot) once their
+# required checks pass. Uses repo auto-merge so the PR cannot land before
+# a later push disables it.
+name: auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: auto-merge:${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Mic92/auto-merge@main

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,6 +87,9 @@ jobs:
         with:
           extra-conf: ${{ env.NIX_EXTRA_CONF }}
 
+      # GHA-cache layer over cache.thalheim.io.
+      - uses: Mic92/hestia@v1
+
       - uses: tailscale/github-action@v3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
@@ -138,6 +141,9 @@ jobs:
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc
         with:
           extra-conf: ${{ env.NIX_EXTRA_CONF }}
+
+      # GHA-cache layer over cache.thalheim.io.
+      - uses: Mic92/hestia@v1
 
       - uses: tailscale/github-action@v3
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,6 +31,8 @@ concurrency:
 permissions:
   actions: read
   contents: read
+  # the wait-buildbot step reads the buildbot check run via the Checks API
+  checks: read
   # check_run-triggered runs are attached to the default branch, not the
   # PR commit; we post a commit status back to the tested sha so the
   # result shows up on the PR.
@@ -78,6 +80,8 @@ jobs:
     if: needs.gate.outputs.has-secrets == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -96,6 +100,9 @@ jobs:
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci
           hostname: tribuchet-hub-${{ github.run_id }}
+
+      # nixbot's cache push lands shortly after buildbot succeeds.
+      - run: python3 .github/scripts/e2e/run.py wait-buildbot "${{ github.event.check_run.head_sha || github.sha }}"
 
       - run: nix build .#default
 
@@ -153,6 +160,9 @@ jobs:
           # Tailscale hostnames are DNS labels; matrix.system can
           # contain '_' (x86_64-linux), so use the sanitised slug.
           hostname: tw-${{ matrix.slug }}-${{ github.run_id }}
+
+      # nixbot's cache push lands shortly after buildbot succeeds.
+      - run: python3 .github/scripts/e2e/run.py wait-buildbot "${{ github.event.check_run.head_sha || github.sha }}"
 
       - run: nix build .#default
 

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -1,0 +1,39 @@
+# Garbage-collect the hestia binary cache so the repo stays inside
+# GitHub's 10 GB cache quota. GC must run on the default branch: a PR
+# job's cache scope is read-only towards it and dies with the PR.
+name: Cache GC
+
+# A second GC's repack races the first's pack deletes; never overlap.
+concurrency:
+  group: hestia-gc
+  cancel-in-progress: false
+
+on:
+  schedule:
+    - cron: "23 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Plan only; do not repack, touch, or delete anything.
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  gc:
+    runs-on: ubuntu-latest
+    permissions:
+      # REST cache deletes need actions:write.
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc
+      # Installs the released hestia binary and captures the cache API
+      # tokens GC needs (HESTIA_BIN points at the binary).
+      - uses: Mic92/hestia@v1
+      - run: "$HESTIA_BIN gc ${{ inputs.dry-run && '--dry-run' || '' }}"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/crates/tribuchet/src/worker/sandbox.rs
+++ b/crates/tribuchet/src/worker/sandbox.rs
@@ -60,9 +60,8 @@ pub struct SandboxSpec {
     /// uid mapped to 1000, like Nix without auto-allocate-uids.
     #[cfg_attr(target_os = "macos", allow(dead_code))]
     pub uid_range: Option<u32>,
-    /// Root workers: unprivileged host uid backing fixed-output builds
-    /// (pasta is rootless-only; network builds should not be backed by
-    /// host root anyway).
+    /// Root workers: unprivileged host uid backing fixed-output builds,
+    /// so a network-facing build never runs as host root.
     #[cfg_attr(target_os = "macos", allow(dead_code))]
     pub fod_uid: Option<u32>,
     /// pasta binary: fixed-output builds get a private netns with

--- a/crates/tribuchet/src/worker/sandbox/linux.rs
+++ b/crates/tribuchet/src/worker/sandbox/linux.rs
@@ -405,13 +405,19 @@ fn fork_pasta_helper(bin: &Path) -> io::Result<PastaHelper> {
                 // build process died before signaling; nothing to do
                 unsafe { libc::_exit(1) }
             }
-            // pasta's default port forwarding and host-loopback
-            // mapping splice host services into the namespace, the
-            // exact leak the private netns is meant to close.
+            // -t/-u/-T/-U none and --map-host-loopback none: pasta's
+            // default port forwarding and host-loopback mapping would
+            // splice host services into the namespace, the exact leak
+            // the private netns closes. --runas 0: the build process is
+            // host root (mapped to an unprivileged uid only inside its
+            // userns), so pasta must stay root to setns into its
+            // /proc/<pid>/ns; it self-isolates afterwards regardless.
             let args: Vec<CString> = [
                 bin.to_string_lossy().as_ref(),
                 "--config-net",
                 "--quiet",
+                "--runas",
+                "0",
                 "--dns-forward",
                 PASTA_DNS,
                 "-t",
@@ -535,18 +541,6 @@ fn setup(p: &SetupParams) -> io::Result<()> {
         | CloneFlags::CLONE_NEWUTS;
     // Network builds keep the host namespace only without pasta;
     // with it they get a private one plus user-mode NAT.
-    // Drop host root before creating any namespace, so the userns
-    // is owned by the unprivileged uid and rootless pasta can
-    // attach to it.
-    if let Some(uid) = p.fod_uid {
-        unistd::setgroups(&[]).map_err(ioerr("fod setgroups"))?;
-        unistd::setgid(unistd::Gid::from_raw(uid)).map_err(ioerr("fod setgid"))?;
-        unistd::setuid(unistd::Uid::from_raw(uid)).map_err(ioerr("fod setuid"))?;
-        // setuid cleared the dumpable flag, which makes /proc/self
-        // root-owned; restore it so the uid/gid map writes below
-        // (and pasta's /proc access) work.
-        prctl::set_dumpable(true).map_err(ioerr("set_dumpable"))?;
-    }
     let private_net = !p.network || p.pasta.is_some();
     if private_net {
         flags |= CloneFlags::CLONE_NEWNET;
@@ -561,8 +555,13 @@ fn setup(p: &SetupParams) -> io::Result<()> {
         // delegated subtree (usable by nspawn inside the sandbox).
         flags |= CloneFlags::CLONE_NEWCGROUP;
     }
-    if p.uid_count == 1 {
-        // Unprivileged self-mapping of the caller's own uid.
+    // Mapping onto a host uid other than the worker's own (uid-range,
+    // or a FOD's backing uid) needs a still-privileged helper in the
+    // parent userns to write the map. Unsharing while root also avoids
+    // the unprivileged-userns restriction some kernels enforce (e.g.
+    // AppArmor on Ubuntu), which would reject the setgroups write
+    // below. Only an unprivileged worker self-maps its own uid.
+    if p.uid_count == 1 && p.fod_uid.is_none() {
         unshare(flags).map_err(ioerr("unshare"))?;
         fs::write("/proc/self/setgroups", "deny").map_err(werr("setgroups"))?;
         fs::write(
@@ -619,10 +618,10 @@ fn setup(p: &SetupParams) -> io::Result<()> {
     }
     apply_process_limits(p.system)?;
 
-    // uid-range: become the in-namespace root the mapping promised;
-    // the worker's own uid is outside the mapped block. Single-uid
-    // builds already run as the mapped uid.
-    if p.uid_count > 1 {
+    // Helper-mapped builds run as the still-root worker, unmapped but
+    // holding all caps in the new userns; drop to the in-namespace uid
+    // the map promised. A self-mapped worker already runs as it.
+    if p.uid_count > 1 || p.fod_uid.is_some() {
         unistd::setgroups(&[]).map_err(ioerr("setgroups"))?;
         unistd::setgid(unistd::Gid::from_raw(p.sandbox_gid)).map_err(ioerr("setgid"))?;
         unistd::setuid(unistd::Uid::from_raw(p.sandbox_uid)).map_err(ioerr("setuid"))?;

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -79,6 +79,18 @@ in
             hubIp = "${nodes.hub.networking.primaryIPAddress}";
           }
         '';
+        environment.etc."tt/fod-dns.nix".text = ''
+          import ${./tests/fod-dns.nix} {
+            bash = "${pkgs.bash}";
+            host = "fod-dns.test";
+          }
+        '';
+        environment.etc."tt/fod-hosts.nix".text = ''
+          import ${./tests/fod-dns.nix} {
+            bash = "${pkgs.bash}";
+            host = "fod-hosts.test";
+          }
+        '';
         environment.etc."tt/logbomb.nix".text = ''
           import ${./tests/logbomb.nix} { bash = "${pkgs.bash}"; }
         '';
@@ -139,12 +151,28 @@ in
       };
 
     worker =
-      { pkgs, ... }:
+      { pkgs, nodes, ... }:
       {
+        # Resolvable only via /etc/hosts; the FOD-via-files subtest
+        # fetches the hub through this name.
+        networking.hosts."${nodes.hub.networking.primaryIPAddress}" = [ "fod-hosts.test" ];
         environment.systemPackages = [
           tribuchet
           pkgs.python3
         ];
+        # Resolver for the FOD-via-DNS subtest; pasta forwards the
+        # sandbox's queries here. The record is dropped into addn-hosts
+        # at test time, once the hub IP is known.
+        services.dnsmasq = {
+          enable = true;
+          resolveLocalQueries = false;
+          settings = {
+            no-resolv = true;
+            addn-hosts = "/var/lib/dnsmasq-fod";
+          };
+        };
+        systemd.tmpfiles.rules = [ "d /var/lib/dnsmasq-fod 0755 root root -" ];
+        networking.nameservers = [ "127.0.0.1" ];
         # Private store image instead of the shared host store, so input
         # paths the worker lacks really travel over the wire.
         virtualisation.useNixStoreImage = true;
@@ -405,6 +433,25 @@ in
         worker.succeed("systemd-run --unit=loopsrv python3 -m http.server 9999 --bind 127.0.0.1")
         worker.wait_for_open_port(9999)
         out = hub.succeed("nix-build /etc/tt/fod.nix --no-out-link").strip()
+        hub.succeed(f"grep -q hello-fod {out}")
+
+    with subtest("fixed-output build resolves a hostname via /etc/hosts"):
+        # fodsrv still listens on the hub's :8765. fod-hosts.test is in
+        # the worker's /etc/hosts but not in dnsmasq, so resolving it
+        # exercises the files source.
+        worker.succeed("grep -q fod-hosts.test /etc/hosts")
+        out = hub.succeed("nix-build /etc/tt/fod-hosts.nix --no-out-link").strip()
+        hub.succeed(f"grep -q hello-fod {out}")
+
+    with subtest("fixed-output build resolves a hostname via pasta's DNS forwarder"):
+        # fod-dns.test is served only by dnsmasq, never in /etc/hosts,
+        # so the lookup must go through pasta's forwarder.
+        hubip = worker.succeed("getent hosts hub | awk '{print $1}'").strip()
+        worker.succeed(f"echo '{hubip} fod-dns.test' > /var/lib/dnsmasq-fod/fod.hosts")
+        worker.succeed("systemctl restart dnsmasq")
+        worker.wait_until_succeeds("getent hosts fod-dns.test")
+        worker.fail("grep -q fod-dns.test /etc/hosts")
+        out = hub.succeed("nix-build /etc/tt/fod-dns.nix --no-out-link").strip()
         hub.succeed(f"grep -q hello-fod {out}")
 
     with subtest("aarch64 build runs under per-sandbox binfmt emulation"):

--- a/nix/tests/fod-dns.nix
+++ b/nix/tests/fod-dns.nix
@@ -1,0 +1,19 @@
+# Like fod.nix, but reaches the hub's TCP server through a hostname so
+# the build resolves a name with getaddrinfo. Caller picks a name that
+# resolves via /etc/hosts or only via DNS.
+{ bash, host }:
+derivation {
+  name = "tt-fod-dns";
+  system = "x86_64-linux";
+  builder = builtins.storePath bash + "/bin/bash";
+  args = [
+    "-c"
+    ''
+      exec 3<>/dev/tcp/${host}/8765
+      while IFS= read -r l <&3; do printf '%s\n' "$l"; done > $out
+    ''
+  ];
+  outputHashAlgo = "sha256";
+  outputHashMode = "flat";
+  outputHash = "fba0ea84c93fbcbfff10a9b33bc33409b5fd15eff0540b7b4389d691cde59fe8";
+}


### PR DESCRIPTION
Fixed-output derivations are the only builds with network access, and
name resolution inside the sandbox has two paths: the host's /etc/hosts
copied in (the files nsswitch source) and real DNS, which on Linux goes
through pasta's in-namespace forwarder. Neither was tested -- the
existing FOD test connects to a raw IP.

- nix/tests/fod-dns.nix: FOD that fetches the hub through a hostname.
- NixOS test: two subtests, one name resolvable only via /etc/hosts, one
  served only by dnsmasq so pasta must forward it.
- e2e probe-fod.nix: builder resolves a hostname and does a TLS fetch;
  runId keeps it uncached so it runs on the worker (seatbelt network* on
  macOS, pasta on Linux).