### PR TITLE
worker: dedupe concurrent input imports to break a staging deadlock

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -45,9 +45,12 @@ GC by per-build temp roots. The worker must be a trusted daemon user
 2. Hub validates the request (store dir pinned to `/nix/store`, store-path
    basenames restricted to Nix's name charset, absolute builder,
    `tmpDirInSandbox` pinned to `/build`, no duplicate or input-aliasing
-   outputs) and dedupes by a hash of the full request: a second identical
-   request attaches to the in-flight build's log and result, and a
-   *different* request claiming an in-flight scratch path is rejected.
+   outputs) and dedupes by a hash of the request minus the per-attempt
+   `topTmpDir`. Nix derives the scratch outputs deterministically from
+   the drvPath, so submissions of the same derivation hash identically:
+   a matching request attaches to the in-flight build's log and result,
+   while a *different* request claiming an in-flight scratch path is
+   rejected.
    Otherwise it queues the request for a worker matching `system` (and
    later: required features). A system no connected worker serves is
    rejected immediately; otherwise submitters block and Nix's max-jobs
@@ -179,10 +182,6 @@ capable worker is left (or get rebuilt by another one).
 
 ## Known limitations (MVP)
 
-* Dedupe is keyed on the scratch output set, which Nix randomizes per
-  build attempt: it only catches concurrent duplicate submissions of the
-  same goal, not the same derivation submitted twice. Proper dedupe
-  needs a derivation identity in build.json (upstream patch).
 * Workers run up to `max-jobs` concurrent builds over one session.
 * The hub's tmp-dir tar and the worker's unpack walk their trees
   through directory fds with O_NOFOLLOW, but NAR pack/unpack go through

--- a/crates/tribuchet/src/hub/submit.rs
+++ b/crates/tribuchet/src/hub/submit.rs
@@ -382,6 +382,17 @@ mod tests {
         assert_ne!(a, dedupe_key(&req));
     }
 
+    /// Two submissions of the same derivation differ only in the
+    /// per-attempt `topTmpDir`; the key ignores it so they dedupe.
+    #[test]
+    fn dedupe_key_ignores_per_attempt_top_tmp_dir() {
+        let a = base_request();
+        let mut b = base_request();
+        b.top_tmp_dir = "/nix/var/nix/builds/nix-1909052-1544484239".into();
+        assert_ne!(a.top_tmp_dir, b.top_tmp_dir);
+        assert_eq!(dedupe_key(&a), dedupe_key(&b));
+    }
+
     /// Strings shifted between adjacent sections must not collide:
     /// args `["-c", "K", "V"]` with no env and args `["-c"]` with
     /// env `{K: V}` would feed identical bytes without section counts.

--- a/crates/tribuchet/src/worker.rs
+++ b/crates/tribuchet/src/worker.rs
@@ -14,6 +14,7 @@ pub mod binfmt;
 mod build;
 mod caps;
 mod cgroup;
+mod imports;
 mod logtail;
 pub mod reaper;
 mod resume;
@@ -453,12 +454,16 @@ async fn session(
     }
 
     let mut active: HashMap<String, ActiveBuild> = HashMap::new();
+    // Deduplicates concurrent input imports across this session's
+    // builds; dropped with the session so a reconnect starts clean.
+    let imports = imports::SessionImports::new();
     let result = session_loop(
         &mut inbound,
         &mut active,
         &out_tx,
         signing_key,
         ctx,
+        &imports,
         Duration::from_secs(opts.build_timeout_secs),
     )
     .await;
@@ -476,6 +481,7 @@ async fn session_loop(
     out_tx: &mpsc::Sender<WorkerMessage>,
     signing_key: &Arc<SecretKey>,
     ctx: &Arc<WorkerCtx>,
+    imports: &imports::SessionImports,
     build_timeout: Duration,
 ) -> Result<()> {
     while let Some(m) = inbound.message().await? {
@@ -516,7 +522,7 @@ async fn session_loop(
                 let Some(build) = active.get_mut(&offer.build_id) else {
                     continue;
                 };
-                match build.negotiate(&offer.store_paths).await {
+                match build.negotiate(&offer.store_paths, imports).await {
                     Ok(missing) => {
                         out_tx
                             .send(msg(worker_message::Msg::MissingPaths(MissingPaths {
@@ -545,7 +551,7 @@ async fn session_loop(
                         Ok(false) => {}
                         Ok(true) => {
                             let build = active.remove(&id).unwrap();
-                            launch_build(ctx, build, out_tx, signing_key, build_timeout);
+                            launch_when_staged(ctx, build, out_tx, signing_key, build_timeout);
                         }
                     }
                 }
@@ -623,6 +629,44 @@ fn launch_build(
         ctx.running.fetch_sub(1, atomic::Ordering::Relaxed);
         record_finished(&ctx, &key, fin);
         let _ = out_tx.blocking_send(request_job());
+    });
+}
+
+/// A fully-staged build launches at once, unless some of its inputs are
+/// imported by sibling builds: then wait for those off the session loop
+/// (which must keep feeding the sibling imports) before launching.
+fn launch_when_staged(
+    ctx: &Arc<WorkerCtx>,
+    mut build: ActiveBuild,
+    out_tx: &mpsc::Sender<WorkerMessage>,
+    signing_key: &Arc<SecretKey>,
+    build_timeout: Duration,
+) {
+    let awaited = build.take_awaited();
+    if awaited.is_empty() {
+        launch_build(ctx, build, out_tx, signing_key, build_timeout);
+        return;
+    }
+    let ctx = ctx.clone();
+    let out_tx = out_tx.clone();
+    let signing_key = signing_key.clone();
+    let build_id = build.assignment.build_id.clone();
+    tokio::spawn(async move {
+        let mut ok = true;
+        for wait in awaited {
+            ok &= wait.wait().await;
+        }
+        if ok {
+            launch_build(&ctx, build, &out_tx, &signing_key, build_timeout);
+        } else {
+            build.abort().await;
+            let _ = fail_build(
+                &out_tx,
+                &build_id,
+                &anyhow::anyhow!("a shared input import failed on another build"),
+            )
+            .await;
+        }
     });
 }
 

--- a/crates/tribuchet/src/worker/build.rs
+++ b/crates/tribuchet/src/worker/build.rs
@@ -20,6 +20,7 @@ use sha2::{Digest, Sha256};
 use tokio::sync::mpsc;
 
 use super::caps::requires_uid_range;
+use super::imports::{Claim, ImportGuard, ImportWait, SessionImports};
 use super::logtail::tail_log;
 use super::resume::{FinishedBuild, PackedExtra, PackedOutput, ResumeState};
 use super::{cgroup, reaper, sandbox, unix_now, DaemonConn, WorkerCtx};
@@ -175,6 +176,12 @@ pub(super) struct ActiveBuild {
     daemon: Option<DaemonConn>,
     importer: Option<Importer>,
     tmp_unpacker: Option<Unpacker>,
+    /// Missing paths this build owns the import of (deduped across the
+    /// session); the guard wakes sibling builds awaiting the same path.
+    owned: HashMap<String, ImportGuard>,
+    /// Missing paths a sibling build imports; this build waits for them
+    /// to settle before it may launch (they are bind-mount sources).
+    awaited: Vec<ImportWait>,
 }
 
 fn store_base(store_path: &str) -> &str {
@@ -220,10 +227,21 @@ impl ActiveBuild {
             daemon: None,
             importer: None,
             tmp_unpacker: None,
+            owned: HashMap::new(),
+            awaited: Vec::new(),
         })
     }
 
-    pub(super) async fn negotiate(&mut self, offered: &[String]) -> Result<Vec<String>> {
+    /// Sibling-import waits to satisfy before this build may launch.
+    pub(super) fn take_awaited(&mut self) -> Vec<ImportWait> {
+        std::mem::take(&mut self.awaited)
+    }
+
+    pub(super) async fn negotiate(
+        &mut self,
+        offered: &[String],
+        imports: &SessionImports,
+    ) -> Result<Vec<String>> {
         let store_dir = StoreDir::default();
         let mut daemon = DaemonClient::builder()
             .connect_daemon()
@@ -250,9 +268,20 @@ impl ActiveBuild {
                 .with_context(|| format!("querying validity of {p}"))?
             {
                 self.inputs.push(p.clone());
-            } else {
-                self.pending.insert(p.clone(), None);
-                missing.push(p.clone());
+                continue;
+            }
+            // One owner per missing path imports it; siblings await it.
+            match imports.claim(p) {
+                Claim::Owner(guard) => {
+                    self.owned.insert(p.clone(), guard);
+                    self.pending.insert(p.clone(), None);
+                    missing.push(p.clone());
+                }
+                Claim::Awaiter(wait) => {
+                    // Imported by a sibling; valid as an input by launch.
+                    self.inputs.push(p.clone());
+                    self.awaited.push(wait);
+                }
             }
         }
         self.daemon = Some(daemon);
@@ -321,6 +350,11 @@ impl ActiveBuild {
             res?;
             if send_failed {
                 bail!("input import ended early for {}", n.store_path);
+            }
+            // Committed: wake siblings awaiting this path. A guard left
+            // in `owned` (build aborts first) signals failure on drop.
+            if let Some(guard) = self.owned.remove(&n.store_path) {
+                guard.complete(true);
             }
             self.inputs.push(n.store_path);
         }

--- a/crates/tribuchet/src/worker/imports.rs
+++ b/crates/tribuchet/src/worker/imports.rs
@@ -1,0 +1,144 @@
+//! Per-session dedup of input-NAR imports across concurrent builds.
+//!
+//! Builds sharing a session have overlapping input closures. Two builds
+//! importing the same missing path concurrently both take the
+//! nix-daemon's per-path lock; since the session feeds NAR chunks
+//! serially, the lock-holder can stall behind the lock-waiter and
+//! deadlock. `SessionImports` gives each missing path one owner that
+//! imports it; other builds await the owner instead. One import per
+//! path: no lock contention, no redundant transfer.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use tokio::sync::watch;
+
+/// Outcome of claiming a path: `Some(true)` imported successfully,
+/// `Some(false)` the owner failed (or dropped without finishing).
+type Outcome = Option<bool>;
+
+/// Session-scoped registry of in-flight/finished input imports. Dropped
+/// when the hub session ends; a fresh session re-checks path validity
+/// against the daemon, so already-imported paths are simply no longer
+/// missing.
+#[derive(Default)]
+pub(super) struct SessionImports {
+    map: Mutex<HashMap<String, watch::Receiver<Outcome>>>,
+}
+
+/// The caller's role for one path.
+pub(super) enum Claim {
+    /// This build must fetch and import the path; complete the guard
+    /// when the import settles.
+    Owner(ImportGuard),
+    /// Another build is already importing the path; await its result.
+    Awaiter(ImportWait),
+}
+
+/// Held by the owning build until its import settles. Completing it (or
+/// dropping it) wakes every awaiter; a drop without `complete` reports
+/// failure so awaiters do not hang on an abandoned import.
+pub(super) struct ImportGuard {
+    tx: watch::Sender<Outcome>,
+    settled: bool,
+}
+
+/// An awaiter's handle to the owner's eventual result.
+pub(super) struct ImportWait {
+    rx: watch::Receiver<Outcome>,
+}
+
+impl SessionImports {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Claim responsibility for `path`. The first caller owns the
+    /// import; later callers (this session) await that owner.
+    pub(super) fn claim(&self, path: &str) -> Claim {
+        let mut map = self.map.lock().unwrap();
+        if let Some(rx) = map.get(path) {
+            return Claim::Awaiter(ImportWait { rx: rx.clone() });
+        }
+        let (tx, rx) = watch::channel(None);
+        map.insert(path.to_owned(), rx);
+        Claim::Owner(ImportGuard { tx, settled: false })
+    }
+}
+
+impl ImportGuard {
+    /// Record the import result and wake awaiters.
+    pub(super) fn complete(mut self, ok: bool) {
+        self.settled = true;
+        let _ = self.tx.send(Some(ok));
+    }
+}
+
+impl Drop for ImportGuard {
+    fn drop(&mut self) {
+        // Owner went away without finishing (build aborted, panic):
+        // report failure so awaiters do not wait forever.
+        if !self.settled {
+            let _ = self.tx.send(Some(false));
+        }
+    }
+}
+
+impl ImportWait {
+    /// Block until the owner settles; the bool is its success.
+    pub(super) async fn wait(mut self) -> bool {
+        // wait_for returns immediately if the value already satisfies
+        // the predicate, covering an owner that settled before we
+        // started waiting. A send error (owner dropped its sender
+        // after sending) still leaves the last value observable.
+        match self.rx.wait_for(Option::is_some).await {
+            Ok(v) => v.unwrap_or(false),
+            Err(_) => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn second_claim_awaits_owner_success() {
+        let imports = SessionImports::new();
+        let Claim::Owner(guard) = imports.claim("/nix/store/x") else {
+            panic!("first claim should own");
+        };
+        let Claim::Awaiter(wait) = imports.claim("/nix/store/x") else {
+            panic!("second claim of the same path should await");
+        };
+        let waiter = tokio::spawn(wait.wait());
+        guard.complete(true);
+        assert!(waiter.await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn awaiter_sees_owner_failure() {
+        let imports = SessionImports::new();
+        let Claim::Owner(guard) = imports.claim("/nix/store/x") else {
+            unreachable!()
+        };
+        let Claim::Awaiter(wait) = imports.claim("/nix/store/x") else {
+            unreachable!()
+        };
+        guard.complete(false);
+        assert!(!wait.wait().await);
+    }
+
+    #[tokio::test]
+    async fn dropped_owner_fails_awaiters() {
+        let imports = SessionImports::new();
+        let Claim::Owner(guard) = imports.claim("/nix/store/x") else {
+            unreachable!()
+        };
+        let Claim::Awaiter(wait) = imports.claim("/nix/store/x") else {
+            unreachable!()
+        };
+        drop(guard); // build aborted before importing
+        assert!(!wait.wait().await);
+    }
+}


### PR DESCRIPTION

Builds sharing a hub session have overlapping input closures, so two
would import the same missing store path concurrently. Each
AddToStoreNar takes the nix-daemon's per-path lock, and since the
session loop feeds the multiplexed NAR stream serially, the lock-holder
could stall behind the lock-waiter:

  build A: holds the path lock, daemon waiting for more NAR bytes
  build B: blocked on the same path lock (locks_lock_inode_wait)
  session loop: blocked on B's bounded chunk channel, so A is never fed

The worker then stops reading the socket and backpressure wedges the
hub too. Observed on a 7-output NixOS system build sharing thousands of
paths.

Give each missing path one owner that fetches and imports it; other
builds await the owner's result and treat the path as a soon-valid
input. Imports run on the session loop during staging and never block
on a wait, while the launch-time waits run off the loop, so there is no
cycle. One import per path also drops the redundant transfer.
