### PR TITLE
hub: serialize input staging per worker

### DIFF
--- a/crates/tribuchet/src/hub.rs
+++ b/crates/tribuchet/src/hub.rs
@@ -293,6 +293,11 @@ async fn worker_loop(
     // each received RequestJob funds at most one assignment
     let (req_tx, mut req_rx) = mpsc::channel::<()>(1024);
     let route = tokio::spawn(route_loop(in_rx, router.clone(), req_tx));
+    // Stage one build's inputs at a time per worker: the worker imports
+    // each closure in isolation (references before referrers, no
+    // shared-path lock contention) and a later build sees earlier shared
+    // inputs as valid, so it fetches only its delta.
+    let staging = Arc::new(tokio::sync::Semaphore::new(1));
 
     let mut credits: usize = 0;
     'outer: loop {
@@ -341,8 +346,9 @@ async fn worker_loop(
         let router = router.clone();
         let out_tx = out_tx.clone();
         let vkey = vkey.clone();
+        let staging = staging.clone();
         tokio::spawn(async move {
-            let res = run_job(&state, &job, &vkey, &out_tx, in_rx).await;
+            let res = run_job(&state, &job, &vkey, &out_tx, in_rx, staging).await;
             router.unregister(&job.id);
             // run_job counts the build verdict; only session/hub-side
             // errors reach the branches below.

--- a/crates/tribuchet/src/hub/relay.rs
+++ b/crates/tribuchet/src/hub/relay.rs
@@ -42,7 +42,14 @@ pub(super) async fn run_job(
     vkey: &PublicKey,
     out_tx: &mpsc::Sender<Result<HubMessage, Status>>,
     mut in_rx: mpsc::Receiver<worker_message::Msg>,
+    staging: std::sync::Arc<tokio::sync::Semaphore>,
 ) -> Result<()> {
+    // Held for the whole input-transfer phase so builds do not
+    // interleave their imports; released when execution starts.
+    let permit = staging
+        .acquire_owned()
+        .await
+        .expect("staging semaphore closed");
     let req = &job.req;
     send(
         out_tx,
@@ -75,6 +82,8 @@ pub(super) async fn run_job(
             // restart); skip staging, its result arrives like any other.
             worker_message::Msg::Resumed(_) => {
                 tracing::info!(id = job.id, "worker resumed an in-flight build");
+                // Resume does no staging; let the next build stage.
+                drop(permit);
                 return relay_build(state, job, vkey, out_tx, &mut in_rx).await;
             }
             // A resumed build's log tail can race ahead of its Resumed
@@ -148,6 +157,10 @@ pub(super) async fn run_job(
     }
     stream_tmp_dir(&job.id, job.tmp_dir.clone(), out_tx).await?;
 
+    // Inputs delivered and (being in-order on the stream) committed
+    // before the next build's PathOffer is read: let staging overlap
+    // this build's execution.
+    drop(permit);
     relay_build(state, job, vkey, out_tx, &mut in_rx).await
 }
 

--- a/crates/tribuchet/src/hub/relay.rs
+++ b/crates/tribuchet/src/hub/relay.rs
@@ -295,39 +295,57 @@ async fn query_path_infos(
 }
 
 /// NAR-pack a local store path, zstd-compress, and stream it to the
-/// worker. Filesystem reads run on harmonia's blocking pool; the zstd
-/// level-3 encode here is cheap relative to the per-chunk awaits.
+/// worker. The pack (mmap page-faults reading the store off disk, plus
+/// the zstd encode) runs on the blocking pool so it neither stalls the
+/// async runtime workers nor blocks the network send it feeds; the two
+/// overlap through the bounded channel.
 async fn stream_store_path(
     build_id: &str,
     store_path: &str,
     out_tx: &mpsc::Sender<Result<HubMessage, Status>>,
 ) -> Result<()> {
-    use tokio::io::AsyncReadExt as _;
-    let nar = harmonia_file_nar::archive::NarByteStream::new(PathBuf::from(store_path));
-    let mut enc = async_compression::tokio::bufread::ZstdEncoder::with_quality(
-        tokio_util::io::StreamReader::new(nar),
-        async_compression::Level::Precise(3),
-    );
-    let mut buf = vec![0u8; crate::chunkio::CHUNK_SIZE];
-    loop {
-        let n = enc
-            .read(&mut buf)
-            .await
-            .with_context(|| format!("packing {store_path}"))?;
-        if n == 0 {
-            break;
-        }
+    let (tx, mut rx) = mpsc::channel::<Vec<u8>>(8);
+    let path = store_path.to_string();
+    let task = tokio::task::spawn_blocking(move || -> Result<()> {
+        // harmonia's NAR pack is async-only; drive it on a current-thread
+        // runtime here so its blocking file reads stay off the shared
+        // runtime workers.
+        use tokio::io::AsyncReadExt as _;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .context("building NAR pack runtime")?;
+        rt.block_on(async move {
+            let nar = harmonia_file_nar::archive::NarByteStream::new(PathBuf::from(&path));
+            let mut enc = async_compression::tokio::bufread::ZstdEncoder::with_quality(
+                tokio_util::io::StreamReader::new(nar),
+                async_compression::Level::Precise(3),
+            );
+            let mut buf = vec![0u8; crate::chunkio::CHUNK_SIZE];
+            loop {
+                let n = enc.read(&mut buf).await.with_context(|| format!("packing {path}"))?;
+                if n == 0 {
+                    break;
+                }
+                if tx.send(buf[..n].to_vec()).await.is_err() {
+                    break; // consumer gone
+                }
+            }
+            Ok(())
+        })
+    });
+    while let Some(chunk) = rx.recv().await {
         send(
             out_tx,
             hub_message::Msg::Nar(NarTransfer {
                 build_id: build_id.into(),
                 store_path: store_path.into(),
-                payload: Some(nar_transfer::Payload::ZstdNarChunk(buf[..n].to_vec())),
+                payload: Some(nar_transfer::Payload::ZstdNarChunk(chunk)),
                 eof: false,
             }),
         )
         .await?;
     }
+    task.await??;
     send(
         out_tx,
         hub_message::Msg::Nar(NarTransfer {

--- a/crates/tribuchet/src/hub/relay.rs
+++ b/crates/tribuchet/src/hub/relay.rs
@@ -235,15 +235,13 @@ fn order_by_references(infos: Vec<PathInfoMsg>) -> Vec<PathInfoMsg> {
         .collect()
 }
 
-async fn query_path_infos(
+/// Per-path query info from one daemon connection, for a slice of paths.
+async fn query_path_info_chunk(
     pool: &harmonia_store_remote::ConnectionPool,
     paths: &[String],
 ) -> Result<Vec<PathInfoMsg>> {
     use harmonia_store_path::{StoreDir, StorePath};
     use harmonia_store_remote::DaemonStore as _;
-    if paths.is_empty() {
-        return Ok(Vec::new());
-    }
     let store_dir = StoreDir::default();
     let mut guard = pool
         .acquire()
@@ -276,6 +274,24 @@ async fn query_path_infos(
         });
     }
     Ok(out)
+}
+
+async fn query_path_infos(
+    pool: &harmonia_store_remote::ConnectionPool,
+    paths: &[String],
+) -> Result<Vec<PathInfoMsg>> {
+    // Spread the per-path query_path_info round trips over several
+    // daemon connections; the pool caps real concurrency (one per CPU).
+    const PARALLELISM: usize = 8;
+    if paths.is_empty() {
+        return Ok(Vec::new());
+    }
+    let chunk_size = paths.len().div_ceil(PARALLELISM).max(1);
+    let chunks = paths
+        .chunks(chunk_size)
+        .map(|chunk| query_path_info_chunk(pool, chunk));
+    let results = futures_util::future::try_join_all(chunks).await?;
+    Ok(results.into_iter().flatten().collect())
 }
 
 /// NAR-pack a local store path, zstd-compress, and stream it to the

--- a/crates/tribuchet/src/worker/build.rs
+++ b/crates/tribuchet/src/worker/build.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
-use harmonia_store_path::{StoreDir, StorePath};
+use harmonia_store_path::{StoreDir, StorePath, StorePathSet};
 use harmonia_store_path_info::ValidPathInfo;
 use harmonia_store_remote::{DaemonClient, DaemonStore};
 use harmonia_utils_signature::SecretKey;
@@ -247,7 +247,8 @@ impl ActiveBuild {
             .connect_daemon()
             .await
             .context("connecting to the local nix-daemon")?;
-        let mut missing = Vec::new();
+        let mut parsed = Vec::with_capacity(offered.len());
+        let mut set = StorePathSet::new();
         for p in offered {
             // Only real store paths may become bind-mount sources; a
             // compromised hub must not get the worker's own files
@@ -262,11 +263,17 @@ impl ActiveBuild {
                 .add_temp_root(&sp)
                 .await
                 .with_context(|| format!("adding temp root for {p}"))?;
-            if daemon
-                .is_valid_path(&sp)
-                .await
-                .with_context(|| format!("querying validity of {p}"))?
-            {
+            set.insert(sp.clone());
+            parsed.push((p, sp));
+        }
+        // One bulk validity query instead of a round trip per path.
+        let valid = daemon
+            .query_valid_paths(&set, false)
+            .await
+            .context("querying valid paths")?;
+        let mut missing = Vec::new();
+        for (p, sp) in parsed {
+            if valid.contains(&sp) {
                 self.inputs.push(p.clone());
                 continue;
             }

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -380,6 +380,46 @@ in
         elapsed = time.time() - t0
         assert elapsed < 27, f"builds did not overlap: {elapsed:.0f}s (serial would be >=30s)"
 
+    with subtest("concurrent builds share a missing input closure"):
+        # Two runtime-added paths the worker lacks, the referrer
+        # embedding the reference's path so Nix records the edge: the
+        # worker must import the reference before the referrer. Several
+        # builds depend on both, dispatched at once, so the worker would
+        # otherwise import the same paths concurrently -- contending on
+        # the daemon path lock (deadlock) or importing a referrer before
+        # its reference is valid. Per-worker staging serialization makes
+        # each build import the closure in isolation; the size widens
+        # the window a racy implementation would lose in.
+        hub.succeed("head -c 4000000 /dev/urandom > /root/ref")
+        ref = hub.succeed("nix-store --add /root/ref").strip()
+        hub.succeed(
+            f"head -c 4000000 /dev/urandom > /root/referrer; echo {ref} >> /root/referrer"
+        )
+        referrer = hub.succeed("nix-store --add /root/referrer").strip()
+        hub.succeed(
+            "cat > /root/shared.nix << 'NIXEOF'\n"
+            "let\n"
+            "  bash = builtins.storePath \"${pkgs.bash}\";\n"
+            f"  referrer = builtins.storePath \"{referrer}\";\n"
+            "  mk = n: derivation {\n"
+            "    name = \"tt-shared-\" + n;\n"
+            "    system = \"x86_64-linux\";\n"
+            "    builder = bash + \"/bin/bash\";\n"
+            "    args = [ \"-c\" (\"test -s \" + referrer + \"; echo shared-ok-\" + n + \" > $out\") ];\n"
+            "  };\n"
+            "in [ (mk \"a\") (mk \"b\") (mk \"c\") ]\n"
+            "NIXEOF"
+        )
+        # The reference must be missing on the worker for the closure to
+        # travel; drop it there in case an earlier subtest imported it.
+        worker.succeed(f"nix-store --delete {ref} {referrer} 2>/dev/null || true")
+        outs = hub.succeed(
+            "nix-build /root/shared.nix --no-out-link --max-jobs 2", timeout=120
+        ).strip().split()
+        assert len(outs) == 3, f"expected 3 outputs, got {outs}"
+        for o in outs:
+            hub.succeed(f"grep -q shared-ok- {o}")
+
     with subtest("uid-range build runs as sandbox root with a cgroup"):
         out = hub.succeed("nix-build /etc/tt/uidrange.nix --no-out-link").strip()
         hub.succeed(f"grep -q uid-range-ok {out}")


### PR DESCRIPTION

The hub dispatched a worker's builds concurrently and its per-job tasks
interleaved input-NAR streaming on the shared worker stream, so the
worker imported the same missing store path from two builds at once.
AddToStoreNar takes the nix-daemon's per-path lock, and since the worker
reads the multiplexed stream serially it deadlocked:

  build A: holds the path lock, daemon waiting for more NAR bytes
  build B: blocked on the same path lock (locks_lock_inode_wait)
  session loop: blocked on B's bounded chunk channel, so A is never fed

The worker then stopped reading the socket and backpressure wedged the
hub (observed: a 7-output NixOS system build, 2.4G buffered, both idle).
Interleaving could also import a referrer before its reference was
registered ("path is not valid").

Hold a per-worker permit for each build's whole input-transfer phase,
released when execution starts. The worker processes its stream in order
and commits every import before reading the next build's PathOffer, so
each closure imports in isolation (references before referrers, no lock
contention) and a later build sees earlier shared inputs as valid,
fetching only its delta. Execution still overlaps.
