### PR TITLE
name runtime and blocking-pool threads

### DIFF
--- a/crates/tribuchet/src/attach.rs
+++ b/crates/tribuchet/src/attach.rs
@@ -23,7 +23,7 @@ use crate::proto::{attach_event, attach_hub_client::AttachHubClient, BuildReques
 
 pub fn run(build_json: &Path, socket: &Path) -> Result<()> {
     let build = BuildJson::load(build_json)?;
-    let rt = tokio::runtime::Runtime::new()?;
+    let rt = crate::rt::runtime("trib-attach")?;
     let code = rt.block_on(run_async(build, socket.to_owned(), build_json.to_owned()))?;
     // Unix exposes only the low 8 bits of the exit status; never let a
     // nonzero code collapse to an observed 0.

--- a/crates/tribuchet/src/hub.rs
+++ b/crates/tribuchet/src/hub.rs
@@ -511,7 +511,7 @@ fn configure_auth(
 }
 
 pub fn run(cfg: crate::config::HubConfig) -> Result<()> {
-    let rt = tokio::runtime::Runtime::new()?;
+    let rt = crate::rt::runtime("trib-hub")?;
     rt.block_on(run_async(cfg))
 }
 

--- a/crates/tribuchet/src/hub/relay.rs
+++ b/crates/tribuchet/src/hub/relay.rs
@@ -307,10 +307,11 @@ async fn stream_store_path(
     let (tx, mut rx) = mpsc::channel::<Vec<u8>>(8);
     let path = store_path.to_string();
     let task = tokio::task::spawn_blocking(move || -> Result<()> {
+        use tokio::io::AsyncReadExt as _;
+        crate::rt::name_current_thread("trib-pack");
         // harmonia's NAR pack is async-only; drive it on a current-thread
         // runtime here so its blocking file reads stay off the shared
         // runtime workers.
-        use tokio::io::AsyncReadExt as _;
         let rt = tokio::runtime::Builder::new_current_thread()
             .build()
             .context("building NAR pack runtime")?;

--- a/crates/tribuchet/src/main.rs
+++ b/crates/tribuchet/src/main.rs
@@ -7,6 +7,7 @@ mod fsutil;
 mod hub;
 mod nar;
 mod proto;
+mod rt;
 mod sd;
 mod store;
 mod tailscale;

--- a/crates/tribuchet/src/rt.rs
+++ b/crates/tribuchet/src/rt.rs
@@ -1,0 +1,29 @@
+//! Shared tokio runtime construction and thread naming, so a profile or
+//! `top -H` can tell which role (and which kind of work) a thread runs.
+
+use std::io;
+
+/// A multi-threaded runtime whose worker and blocking-pool threads carry
+/// `name`. Mirrors the defaults of `Runtime::new` otherwise.
+pub fn runtime(name: &'static str) -> io::Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name(name)
+        .build()
+}
+
+/// Rename the calling OS thread (Linux caps the name at 15 bytes). Used
+/// to tag blocking-pool threads by the work they currently run, which the
+/// runtime otherwise names uniformly.
+pub fn name_current_thread(name: &str) {
+    #[cfg(target_os = "linux")]
+    if let Ok(c) = std::ffi::CString::new(name) {
+        // SAFETY: `c` is a valid NUL-terminated string for the call's
+        // duration and pthread_self() is always valid for this thread.
+        unsafe {
+            libc::pthread_setname_np(libc::pthread_self(), c.as_ptr());
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    let _ = name;
+}

--- a/crates/tribuchet/src/worker.rs
+++ b/crates/tribuchet/src/worker.rs
@@ -255,7 +255,7 @@ pub fn run(opts: WorkerConfig) -> Result<()> {
     // before tokio because the reaper must stay single-threaded.
     let spawner = reaper::ensure(&opts.state_dir.join("exited"))?;
     let cgroup_base = std::env::var(reaper::CGROUP_ENV).ok().map(PathBuf::from);
-    let rt = tokio::runtime::Runtime::new()?;
+    let rt = crate::rt::runtime("trib-worker")?;
     rt.block_on(run_async(opts, spawner, cgroup_base))
 }
 


### PR DESCRIPTION

Profiles and top -H showed every thread as the same default tokio name,
so hub, worker and attach runtimes, and the store-path pack running on
the blocking pool, were indistinguishable. Name the runtime per role
(trib-hub/worker/attach) and tag the pack blocking thread trib-pack.
