### PR TITLE
worker, attach: log the fixed-output network decision

### DIFF
--- a/crates/tribuchet/src/attach.rs
+++ b/crates/tribuchet/src/attach.rs
@@ -42,6 +42,7 @@ const RECONNECT_DELAY: Duration = Duration::from_secs(2);
 
 async fn run_async(build: BuildJson, socket: PathBuf, build_json_path: PathBuf) -> Result<i32> {
     let fixed_output = build.is_fixed_output();
+    tracing::info!(fixed_output, system = %build.system, "submitting build");
     let req = BuildRequest {
         system: build.system,
         builder: build.builder,

--- a/crates/tribuchet/src/worker/build.rs
+++ b/crates/tribuchet/src/worker/build.rs
@@ -416,6 +416,13 @@ impl ActiveBuild {
                 nix_daemon_socket: None,
             },
         )?;
+        tracing::info!(
+            id = a.build_id,
+            fixed_output = a.fixed_output,
+            network = spec.network,
+            pasta = spec.pasta.is_some(),
+            "sandbox network decision"
+        );
         spec.cgroup = self
             .ctx
             .cgroup_base


### PR DESCRIPTION

Nothing logged whether a build was fixed-output, got network, or spawned
pasta, leaving FOD network failures undiagnosable from the journal. Log
the computed fixed_output in attach and the network/pasta decision in the
worker.


