### PR TITLE
worker: default /bin/sh to a static sandbox shell

### DIFF
--- a/crates/tribuchet/build.rs
+++ b/crates/tribuchet/build.rs
@@ -5,5 +5,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Ok(p) = std::env::var("TRIBUCHET_PASTA") {
         println!("cargo:rustc-env=TRIBUCHET_PASTA={p}");
     }
+    // Baked-in default for --sandbox-bin-sh (set by the Nix package).
+    println!("cargo:rerun-if-env-changed=TRIBUCHET_BIN_SH");
+    if let Ok(p) = std::env::var("TRIBUCHET_BIN_SH") {
+        println!("cargo:rustc-env=TRIBUCHET_BIN_SH={p}");
+    }
     Ok(())
 }

--- a/crates/tribuchet/src/build_json.rs
+++ b/crates/tribuchet/src/build_json.rs
@@ -37,19 +37,12 @@ impl BuildJson {
         Ok(parsed)
     }
 
-    /// Fixed-output derivations carry `outputHash` in their environment
-    /// (under structured attrs: inside the `__json` blob, the env's only
-    /// key). They are granted network access in the sandbox.
+    /// Whether this is a fixed-output derivation, granted network in
+    /// the sandbox. Nix sets `NIX_OUTPUT_CHECKED=1` for exactly the
+    /// fixed-output case; build.json carries no output hash, and only
+    /// classic FODs expose `outputHash` in their env.
     pub fn is_fixed_output(&self) -> bool {
-        if self.env.contains_key("outputHash") {
-            return true;
-        }
-        if let Some(json) = self.env.get("__json") {
-            if let Ok(attrs) = serde_json::from_str::<serde_json::Value>(json) {
-                return attrs.get("outputHash").is_some_and(|h| !h.is_null());
-            }
-        }
-        false
+        self.env.get("NIX_OUTPUT_CHECKED").map(String::as_str) == Some("1")
     }
 }
 
@@ -118,11 +111,8 @@ mod tests {
     #[test]
     fn fixed_output_detection() {
         assert!(!doc(&serde_json::json!({})).is_fixed_output());
-        assert!(doc(&serde_json::json!({"outputHash": "sha256-..."})).is_fixed_output());
-        // structured attrs: outputHash lives in the __json blob
-        let env = serde_json::json!({"__json": "{\"outputHash\":\"sha256-...\"}"});
-        assert!(doc(&env).is_fixed_output());
-        let env = serde_json::json!({"__json": "{\"name\":\"x\"}"});
-        assert!(!doc(&env).is_fixed_output());
+        assert!(doc(&serde_json::json!({"NIX_OUTPUT_CHECKED": "1"})).is_fixed_output());
+        // outputHash alone does not grant network; only Nix's flag does
+        assert!(!doc(&serde_json::json!({"outputHash": "sha256-..."})).is_fixed_output());
     }
 }

--- a/crates/tribuchet/src/worker.rs
+++ b/crates/tribuchet/src/worker.rs
@@ -284,9 +284,16 @@ async fn run_async(
         Some(p) => Some(p),
         None => option_env!("TRIBUCHET_PASTA").map(PathBuf::from),
     };
+    // "none" disables the baked-in /bin/sh; else fall back to it so
+    // builds using system(3)/#!/bin/sh work without extra config.
+    opts.sandbox_bin_sh = match opts.sandbox_bin_sh.take() {
+        Some(p) if p.as_os_str() == "none" => None,
+        Some(p) => Some(p),
+        None => option_env!("TRIBUCHET_BIN_SH").map(PathBuf::from),
+    };
     // main logs the config before this baked-in default applies, so it
     // always shows pasta: None; log the effective value.
-    tracing::info!(pasta = ?opts.pasta, "resolved pasta");
+    tracing::info!(pasta = ?opts.pasta, bin_sh = ?opts.sandbox_bin_sh, "resolved sandbox defaults");
     let mut emulators = HashMap::new();
     for (system, path) in &opts.emulate {
         if !cfg!(target_os = "linux") {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -4,6 +4,7 @@
   craneLib,
   protobuf,
   passt,
+  busybox-sandbox-shell,
 }:
 let
   # repository root is one level up from this file
@@ -41,5 +42,7 @@ craneLib.buildPackage (
   // lib.optionalAttrs stdenv.isLinux {
     # default network backend for fixed-output builds
     TRIBUCHET_PASTA = "${passt}/bin/pasta";
+    # static /bin/sh for the sandbox, as Nix uses for its sandbox-shell
+    TRIBUCHET_BIN_SH = "${busybox-sandbox-shell}/bin/busybox";
   }
 )


### PR DESCRIPTION

Without /bin/sh in the sandbox, builds using system(3)/popen(3) or a
#!/bin/sh shebang fail: install-info's `sh -c "gzip -d"` hit ENOENT,
breaking system-path and every NixOS closure.

Bake a static busybox as the default sandbox-bin-sh, as Nix does for its
own sandbox; "none" still disables it.


