### PR TITLE
ci: use hestia beta release for cache

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,7 +81,9 @@ jobs:
           extra-conf: ${{ env.NIX_EXTRA_CONF }}
 
       # GHA-cache layer over cache.thalheim.io.
-      - uses: Mic92/hestia@v1
+      - uses: Mic92/hestia-beta@v2.0.0-beta.1
+        with:
+          version: v2.0.0-beta.1
 
       - uses: tailscale/github-action@v4
         with:
@@ -145,7 +147,9 @@ jobs:
           extra-conf: ${{ env.NIX_EXTRA_CONF }}
 
       # GHA-cache layer over cache.thalheim.io.
-      - uses: Mic92/hestia@v1
+      - uses: Mic92/hestia-beta@v2.0.0-beta.1
+        with:
+          version: v2.0.0-beta.1
 
       - uses: tailscale/github-action@v4
         with:

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -33,7 +33,9 @@ jobs:
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc
       # Installs the released hestia binary and captures the cache API
       # tokens GC needs (HESTIA_BIN points at the binary).
-      - uses: Mic92/hestia@v1
+      - uses: Mic92/hestia-beta@v2.0.0-beta.1
+        with:
+          version: v2.0.0-beta.1
       - run: "$HESTIA_BIN gc ${{ inputs.dry-run && '--dry-run' || '' }}"
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION

Point the workflows at Mic92/hestia-beta v2.0.0-beta.1 to exercise the
upcoming v2 release before it ships from the main repo.


