### PR TITLE
hub: generate a nix.conf fragment from connected workers

### DIFF
--- a/crates/tribuchet/build.rs
+++ b/crates/tribuchet/build.rs
@@ -1,4 +1,5 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=proto/tribuchet.proto");
     tonic_prost_build::compile_protos("proto/tribuchet.proto")?;
     // Baked-in default for --pasta (set by the Nix package).
     println!("cargo:rerun-if-env-changed=TRIBUCHET_PASTA");

--- a/crates/tribuchet/proto/tribuchet.proto
+++ b/crates/tribuchet/proto/tribuchet.proto
@@ -95,6 +95,9 @@ message Register {
   // ed25519 public key used to sign output NARs, in Nix's
   // "name:base64" format (nix-store --generate-binary-cache-key).
   string signing_public_key = 5;
+  // Advisory capacity, summed across workers to size the max-jobs of
+  // the generated nix.conf fragment. Not the RequestJob dispatch path.
+  uint32 max_jobs = 8;
 }
 
 message Heartbeat {

--- a/crates/tribuchet/src/config.rs
+++ b/crates/tribuchet/src/config.rs
@@ -61,6 +61,42 @@ pub struct HubConfig {
     /// register as a worker (auth = tailscale).
     #[serde(default)]
     pub tailscale_allowed_tags: Vec<String>,
+    /// When set, the hub rewrites a nix.conf fragment (the
+    /// external-builders and max-jobs settings) whenever the
+    /// connected-worker set changes, so a local nix-daemon offloads to
+    /// whatever systems are available right now.
+    #[serde(default)]
+    pub nix_config: Option<NixConfig>,
+}
+
+/// A hub-maintained nix.conf fragment. A local nix.conf `include`s the
+/// path; a systemd path unit watching it restarts nix-daemon to apply
+/// changes (in-flight build children survive the restart).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct NixConfig {
+    /// File the fragment is written to.
+    pub path: PathBuf,
+    /// external-builders `program`: the attach shim nix runs.
+    pub attach_program: PathBuf,
+    /// Percent to scale summed worker capacity by for the emitted
+    /// max-jobs (200 = 2x). Oversubscription keeps every worker's queue
+    /// fed regardless of the system mix nix admits into its single
+    /// global slot pool, and hides the per-build dispatch round trip.
+    #[serde(default = "default_oversubscribe_percent")]
+    pub oversubscribe_percent: u32,
+    /// Hard ceiling on the emitted max-jobs. Bounds the local-build
+    /// burst if every worker vanishes and offloaded builds fall back
+    /// to local execution.
+    #[serde(default = "default_max_jobs_cap")]
+    pub max_jobs_cap: u32,
+}
+
+fn default_oversubscribe_percent() -> u32 {
+    200
+}
+fn default_max_jobs_cap() -> u32 {
+    256
 }
 
 fn default_hub_socket() -> PathBuf {

--- a/crates/tribuchet/src/hub.rs
+++ b/crates/tribuchet/src/hub.rs
@@ -85,6 +85,7 @@ impl CapsGuard {
         state.worker_caps.lock().unwrap().insert(id, caps.clone());
         // Wake submissions waiting for a capable worker to appear.
         state.caps_changed.notify_waiters();
+        state.regen_nix_config();
         Self { state, id, caps }
     }
 }
@@ -92,6 +93,7 @@ impl CapsGuard {
 impl Drop for CapsGuard {
     fn drop(&mut self) {
         self.state.worker_caps.lock().unwrap().remove(&self.id);
+        self.state.regen_nix_config();
         // Remember the platform so a build for it briefly waits for the
         // worker to reconnect instead of declining immediately.
         self.state.record_departed(self.caps.clone());
@@ -279,6 +281,7 @@ async fn worker_loop(
             .iter()
             .map(|c| (c.system.clone(), c.features.iter().cloned().collect()))
             .collect(),
+        max_jobs: register.max_jobs,
     };
     let caps_guard = CapsGuard::new(state.clone(), caps.clone());
     let router = Router::default();
@@ -523,9 +526,10 @@ async fn run_async(cfg: crate::config::HubConfig) -> Result<()> {
     let socket = cfg.socket.as_path();
     let listen = cfg.listen.as_str();
     let config_dir = cfg.config_dir.as_path();
-    let state = Arc::new(HubState::new(std::time::Duration::from_secs(
-        cfg.worker_grace_secs,
-    )));
+    let state = Arc::new(HubState::new(
+        std::time::Duration::from_secs(cfg.worker_grace_secs),
+        cfg.nix_config.clone(),
+    ));
 
     let (tls, peer_auth) = configure_auth(&cfg, config_dir)?;
     let trusted_keys = load_trusted_keys(config_dir)?;

--- a/crates/tribuchet/src/hub/state.rs
+++ b/crates/tribuchet/src/hub/state.rs
@@ -1,13 +1,17 @@
 //! In-memory hub state: replay buffers, the job queue, worker capabilities.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::fs;
+use std::io::Write;
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic;
 use std::time::{Duration, Instant};
 
 use tokio::sync::{Mutex, Notify, mpsc};
 use tonic::Status;
+
+use crate::config::NixConfig;
 
 /// How long a build waits for a platform we expect to come back: the
 /// startup window in which workers re-register after a hub restart, and
@@ -187,6 +191,9 @@ pub(super) struct HubState {
     pub(super) caps_changed: Notify,
     /// Build lifecycle counters scraped by the metrics endpoint.
     pub(super) metrics: super::metrics::Metrics,
+    /// When set, the connected-worker set is mirrored to this nix.conf
+    /// fragment on every register/deregister.
+    pub(super) nix_config: Option<NixConfig>,
 }
 
 #[derive(Clone)]
@@ -195,6 +202,48 @@ pub(super) struct WorkerCaps {
     pub(super) name: String,
     /// system -> features the worker honors for it
     pub(super) systems: HashMap<String, HashSet<String>>,
+    /// Advisory concurrent-build capacity, summed to size the
+    /// generated nix.conf max-jobs.
+    pub(super) max_jobs: u32,
+}
+
+/// nix.conf fragment for the connected workers: external-builders over
+/// every served system, and max-jobs at the oversubscribed, capped
+/// aggregate capacity. max-jobs is omitted with no workers, leaving the
+/// base nix.conf default to govern local fallback builds.
+fn render_nix_config(caps: &HashMap<u64, WorkerCaps>, cfg: &NixConfig) -> String {
+    use std::fmt::Write as _;
+
+    let systems: BTreeSet<&str> = caps
+        .values()
+        .flat_map(|c| c.systems.keys().map(String::as_str))
+        .collect();
+    let systems_json = systems
+        .iter()
+        .map(|s| format!("{s:?}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    let mut out = format!(
+        "external-builders = [{{\"systems\":[{systems_json}],\"program\":\"{}\",\"args\":[]}}]\n",
+        cfg.attach_program.display(),
+    );
+    let capacity: u64 = caps.values().map(|c| u64::from(c.max_jobs)).sum();
+    if capacity > 0 {
+        let scaled = capacity * u64::from(cfg.oversubscribe_percent) / 100;
+        let jobs = scaled.clamp(1, u64::from(cfg.max_jobs_cap));
+        let _ = writeln!(out, "max-jobs = {jobs}");
+    }
+    out
+}
+
+fn write_atomic(path: &Path, content: &str) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(content.as_bytes())?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp, path)
 }
 
 impl WorkerCaps {
@@ -207,12 +256,12 @@ impl WorkerCaps {
 
 impl Default for HubState {
     fn default() -> Self {
-        Self::new(WORKER_GRACE)
+        Self::new(WORKER_GRACE, None)
     }
 }
 
 impl HubState {
-    pub(super) fn new(worker_grace: Duration) -> Self {
+    pub(super) fn new(worker_grace: Duration, nix_config: Option<NixConfig>) -> Self {
         Self {
             queue: Mutex::default(),
             inflight: Mutex::default(),
@@ -228,6 +277,32 @@ impl HubState {
             departed: std::sync::Mutex::default(),
             caps_changed: Notify::default(),
             metrics: super::metrics::Metrics::default(),
+            nix_config,
+        }
+    }
+
+    /// Mirror the connected-worker set to the nix.conf fragment. Called
+    /// after a register/deregister mutates `worker_caps`.
+    pub(super) fn regen_nix_config(&self) {
+        let Some(cfg) = &self.nix_config else {
+            return;
+        };
+        // Render and write under the lock so concurrent register/
+        // deregister serialize and never leave stale content behind.
+        let caps = self.worker_caps.lock().unwrap();
+        let content = render_nix_config(&caps, cfg);
+        // Skip the write, and the daemon restart the watching path unit
+        // would trigger, when nothing changed (e.g. a worker reconnects
+        // with the same capabilities).
+        if fs::read_to_string(&cfg.path).is_ok_and(|cur| cur == content) {
+            return;
+        }
+        if let Err(e) = write_atomic(&cfg.path, &content) {
+            tracing::warn!(
+                error = %e,
+                path = %cfg.path.display(),
+                "failed to write nix.conf fragment"
+            );
         }
     }
 }
@@ -401,6 +476,7 @@ mod tests {
                 features.iter().map(|f| (*f).to_owned()).collect(),
             )]
             .into(),
+            max_jobs: 1,
         }
     }
 
@@ -409,16 +485,16 @@ mod tests {
         // Within the startup window any platform is awaited (workers
         // have not re-registered yet); once it lapses a never-seen
         // platform with no departed worker declines at once.
-        let within = HubState::new(Duration::from_secs(30));
+        let within = HubState::new(Duration::from_secs(30), None);
         assert!(within.expected_deadline("aarch64-linux", &[]).is_some());
-        let lapsed = HubState::new(Duration::ZERO);
+        let lapsed = HubState::new(Duration::ZERO, None);
         assert!(lapsed.expected_deadline("aarch64-linux", &[]).is_none());
     }
 
     #[test]
     fn departed_worker_keeps_its_platform_expected() {
         // Past the startup window but inside the reconnect window.
-        let mut state = HubState::new(Duration::from_secs(30));
+        let mut state = HubState::new(Duration::from_secs(30), None);
         state.started_at = Instant::now().checked_sub(Duration::from_mins(1)).unwrap();
         state.record_departed(caps("x86_64-linux", &["kvm"]));
         let kvm = vec!["kvm".to_owned()];
@@ -431,6 +507,50 @@ mod tests {
     }
 
     #[test]
+    fn nix_config_union_systems_and_capped_oversubscribed_jobs() {
+        let cfg = NixConfig {
+            path: "/run/x".into(),
+            attach_program: "/nix/store/attach".into(),
+            oversubscribe_percent: 200,
+            max_jobs_cap: 256,
+        };
+        let mut workers = HashMap::new();
+        workers.insert(1, {
+            let mut c = caps("x86_64-linux", &[]);
+            c.max_jobs = 100;
+            c
+        });
+        workers.insert(2, {
+            let mut c = caps("aarch64-linux", &[]);
+            c.max_jobs = 50;
+            c
+        });
+        let out = render_nix_config(&workers, &cfg);
+        assert!(
+            out.contains(r#""systems":["aarch64-linux","x86_64-linux"]"#),
+            "{out}"
+        );
+        assert!(out.contains(r#""program":"/nix/store/attach""#), "{out}");
+        // (100 + 50) * 2 = 300, clamped to the cap.
+        assert!(out.contains("max-jobs = 256\n"), "{out}");
+    }
+
+    #[test]
+    fn nix_config_without_workers_omits_max_jobs() {
+        let cfg = NixConfig {
+            path: "/run/x".into(),
+            attach_program: "/nix/store/attach".into(),
+            oversubscribe_percent: 200,
+            max_jobs_cap: 256,
+        };
+        let out = render_nix_config(&HashMap::new(), &cfg);
+        assert!(out.contains(r#""systems":[]"#), "{out}");
+        // No worker -> leave max-jobs to the base nix.conf default so a
+        // local fallback build is not run at the offload capacity.
+        assert!(!out.contains("max-jobs"), "{out}");
+    }
+
+    #[test]
     fn worker_caps_feature_matching() {
         let caps = WorkerCaps {
             name: "w1".into(),
@@ -439,6 +559,7 @@ mod tests {
                 ("aarch64-linux".to_owned(), [].into()),
             ]
             .into(),
+            max_jobs: 1,
         };
         assert!(caps.serves("x86_64-linux", &[]));
         assert!(caps.serves("x86_64-linux", &["kvm".into()]));

--- a/crates/tribuchet/src/worker.rs
+++ b/crates/tribuchet/src/worker.rs
@@ -427,6 +427,7 @@ async fn session(
             caps: system_caps(opts, ctx),
             signing_public_key: signing_key.to_public_key().to_string(),
             resumable_keys: ctx.resumable_keys(),
+            max_jobs: opts.max_jobs.max(1),
         })))
         .await?;
 

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -79,11 +79,47 @@ in
     };
     externalBuilders = {
       enable = lib.mkEnableOption "routing this machine's nix-daemon builds through the hub (experimental external-builders feature)";
+      dynamic = lib.mkEnableOption ''
+        deriving external-builders and max-jobs from the workers
+        currently connected to the hub instead of the static `systems`
+        list. The hub writes a nix.conf fragment on every worker
+        register/deregister; a path unit restarts nix-daemon to apply
+        it (in-flight build children survive the restart)
+      '';
       systems = lib.mkOption {
         type = lib.types.listOf lib.types.str;
         default = [ pkgs.stdenv.hostPlatform.system ];
         defaultText = lib.literalExpression "[ pkgs.stdenv.hostPlatform.system ]";
-        description = "Systems handed to tribuchet instead of being built locally.";
+        description = "Systems handed to tribuchet instead of being built locally (static mode; ignored when `dynamic` is set).";
+      };
+      nixConfigPath = lib.mkOption {
+        type = lib.types.path;
+        default = "/run/tribuchet/nix.conf";
+        description = "Path of the hub-generated nix.conf fragment (dynamic mode).";
+      };
+      oversubscribePercent = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 200;
+        description = ''
+          Percent to scale summed worker capacity by for the emitted
+          max-jobs (200 = 2x), capped. Oversubscribing keeps every
+          worker's hub queue fed regardless of the system mix Nix admits
+          into its single global slot pool and hides the
+          submit/dispatch/result/next-admit round trip. The surplus just
+          parks in the hub queue (an attach process plus a build goal on
+          this host, no NAR staged until dispatch).
+        '';
+      };
+      maxJobsCap = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 256;
+        description = ''
+          Ceiling on the emitted max-jobs. Bounds the local-build burst
+          if every worker vanishes and offloaded builds fall back to
+          local execution. `id-count` must cover it: an external build
+          still reserves an auto-allocated uid slot on this host, and
+          the slot pool holds `id-count / 65536` of them.
+        '';
       };
       nixPackage = lib.mkOption {
         type = lib.types.package;
@@ -155,6 +191,8 @@ in
           hub.externalBuilders.nixPackage.appendPatches patches;
       nix.settings = {
         experimental-features = [ "external-builders" ];
+      }
+      // lib.optionalAttrs (!hub.externalBuilders.dynamic) {
         external-builders = builtins.toJSON [
           {
             systems = hub.externalBuilders.systems;
@@ -162,6 +200,30 @@ in
             args = [ ];
           }
         ];
+      };
+    })
+
+    (lib.mkIf (hub.enable && hub.externalBuilders.enable && hub.externalBuilders.dynamic) {
+      # The hub owns external-builders/max-jobs; nix.conf just includes
+      # its fragment (soft include: nix still starts if it is absent).
+      nix.extraOptions = "!include ${hub.externalBuilders.nixConfigPath}\n";
+      services.tribuchet-hub.settings.nix-config = {
+        path = toString hub.externalBuilders.nixConfigPath;
+        attach-program = toString attachWrapper;
+        oversubscribe-percent = hub.externalBuilders.oversubscribePercent;
+        max-jobs-cap = hub.externalBuilders.maxJobsCap;
+      };
+      # Apply a regenerated fragment: restart swaps only the daemon's
+      # accept loop, in-flight build children keep running.
+      systemd.paths.tribuchet-nix-reload = {
+        wantedBy = [ "multi-user.target" ];
+        pathConfig.PathModified = toString hub.externalBuilders.nixConfigPath;
+      };
+      systemd.services.tribuchet-nix-reload = {
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.systemd}/bin/systemctl try-restart nix-daemon.service";
+        };
       };
     })
 


### PR DESCRIPTION
Nix gates external-builder dispatch on the single global max-jobs counter (an external build is a "semi-local" build and consumes a local build slot), so a static max-jobs on the coordinator caps how many builds it can offload regardless of how much worker capacity exists. It also cannot know upfront which systems will have workers.

Let the hub own both. On every worker register/deregister it writes a nix.conf fragment listing external-builders for exactly the systems some worker currently serves, and a max-jobs sized to the summed worker capacity. A local nix.conf soft-includes the file; a systemd path unit restarts nix-daemon to apply changes (in-flight build children survive).

max-jobs is oversubscribed (default 2x, capped): with one global slot pool a single system's jobs would otherwise fill it and starve another system's worker, so admitting past raw capacity keeps every worker's queue fed. Workers now advertise an advisory max_jobs in Register for the sum; the RequestJob credit path still governs actual dispatch. The fragment is rewritten only when its content changes, so a worker reconnecting with the same capabilities does not restart the daemon.