### PR TITLE
hub: serialize only the store import, not path negotiation

### DIFF
--- a/crates/tribuchet/src/hub/relay.rs
+++ b/crates/tribuchet/src/hub/relay.rs
@@ -44,12 +44,6 @@ pub(super) async fn run_job(
     mut in_rx: mpsc::Receiver<worker_message::Msg>,
     staging: std::sync::Arc<tokio::sync::Semaphore>,
 ) -> Result<()> {
-    // Held for the whole input-transfer phase so builds do not
-    // interleave their imports; released when execution starts.
-    let permit = staging
-        .acquire_owned()
-        .await
-        .expect("staging semaphore closed");
     let req = &job.req;
     send(
         out_tx,
@@ -82,8 +76,6 @@ pub(super) async fn run_job(
             // restart); skip staging, its result arrives like any other.
             worker_message::Msg::Resumed(_) => {
                 tracing::info!(id = job.id, "worker resumed an in-flight build");
-                // Resume does no staging; let the next build stage.
-                drop(permit);
                 return relay_build(state, job, vkey, out_tx, &mut in_rx).await;
             }
             // A resumed build's log tail can race ahead of its Resumed
@@ -143,6 +135,14 @@ pub(super) async fn run_job(
         "input path negotiation done"
     );
 
+    // Serialize only the import: negotiation above is read-only on the
+    // worker store, so it runs in parallel (bounded by RequestJob
+    // credits) instead of gating throughput on its round-trip.
+    let permit = staging
+        .acquire_owned()
+        .await
+        .expect("staging semaphore closed");
+
     // The worker imports missing inputs through its Nix daemon, which
     // needs the full ValidPathInfo; ask the local nix-daemon for it.
     // AddToStoreNar also needs a path's references valid first, and
@@ -157,9 +157,8 @@ pub(super) async fn run_job(
     }
     stream_tmp_dir(&job.id, job.tmp_dir.clone(), out_tx).await?;
 
-    // Inputs delivered and (being in-order on the stream) committed
-    // before the next build's PathOffer is read: let staging overlap
-    // this build's execution.
+    // Inputs delivered and (being in-order on the stream) committed;
+    // let the next build's import proceed while this one executes.
     drop(permit);
     relay_build(state, job, vkey, out_tx, &mut in_rx).await
 }


### PR DESCRIPTION

The per-worker staging semaphore was held across the whole input phase,
including the read-only PathOffer -> MissingPaths round-trip. Measured on
eve, that round-trip is ~50ms of worker-side path validation per build;
serializing it capped one worker at ~14.7 builds/s regardless of client
concurrency.

Only the NAR import needs isolation. Acquire the permit after
negotiation so validity checks run in parallel and the semaphore gates
just the import; trivial builds import nothing and no longer serialize.
Throughput on eve rose 2.3x and both workers became utilized.
