### PR TITLE
worker: drop pids.max from per-build cgroups

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -93,7 +93,7 @@ Reference implementations: `nix/src/libstore/unix/build/` and
   `/etc/passwd`, then `pivot_root` + detach of the old root. The uid is
   remapped via the user namespace (no separate build uid yet). When the
   worker's cgroup is delegated (systemd `Delegate=yes`), each build runs
-  in its own cgroup with `pids.max` (and optional `memory.max`), torn
+  in its own cgroup with an optional `memory.max`, torn
   down via `cgroup.kill`. `--sandbox-bin-sh` binds a static shell at
   `/bin/sh` like Nix's busybox sandbox path. Builds requiring the
   `uid-range` system feature get a disjoint 65536-uid block (Nix's

--- a/crates/tribuchet/src/worker/cgroup.rs
+++ b/crates/tribuchet/src/worker/cgroup.rs
@@ -1,22 +1,26 @@
 //! Best-effort cgroup v2 scoping for builds.
 //!
 //! With a delegated cgroup (systemd `Delegate=yes`), each build runs in
-//! a child cgroup with `pids.max` (and optionally `memory.max`), and
-//! teardown uses `cgroup.kill`, which reaches setsid'd escapees no
-//! killpg can. Without delegation builds run unscoped, with a warning.
+//! a child cgroup with an optional `memory.max`, and teardown uses
+//! `cgroup.kill`, which reaches setsid'd escapees no killpg can.
+//! Without delegation builds run unscoped, with a warning.
+//!
+//! No `pids.max`: the pids controller counts threads and a parallel
+//! build on a many-core machine legitimately needs thousands, so
+//! process caps are left to whatever encloses the worker.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
 /// Move this process into a `main` leaf below its own cgroup (cgroup
 /// v2's no-internal-process rule forbids enabling controllers while the
-/// parent holds processes) and enable pids/memory for siblings.
+/// parent holds processes) and enable the memory controller for siblings.
 /// Returns the delegated base, or None when cgroups are unavailable.
 // Only the Linux reaper calls this; builds are unscoped on macOS.
 #[cfg(target_os = "linux")]
 pub fn init() -> Option<PathBuf> {
     let unavailable = |why: &str| {
-        tracing::warn!("cgroup limits disabled: {why}; builds run without pids/memory caps");
+        tracing::warn!("cgroup scoping disabled: {why}; builds run unscoped");
         None
     };
     let Ok(cg) = fs::read_to_string("/proc/self/cgroup") else {
@@ -29,21 +33,16 @@ pub fn init() -> Option<PathBuf> {
     let Ok(controllers) = fs::read_to_string(base.join("cgroup.controllers")) else {
         return unavailable("cannot read cgroup.controllers");
     };
-    if !controllers.split_whitespace().any(|c| c == "pids") {
-        return unavailable("pids controller not delegated (systemd Delegate=yes?)");
-    }
     let main = base.join("main");
     if fs::create_dir_all(&main).is_err() || fs::write(main.join("cgroup.procs"), "0").is_err() {
         return unavailable("cannot move into a leaf cgroup");
     }
-    let mut ctrl = String::from("+pids");
-    if controllers.split_whitespace().any(|c| c == "memory") {
-        ctrl.push_str(" +memory");
-    }
-    if let Err(e) = fs::write(base.join("cgroup.subtree_control"), ctrl) {
+    if controllers.split_whitespace().any(|c| c == "memory")
+        && let Err(e) = fs::write(base.join("cgroup.subtree_control"), "+memory")
+    {
         return unavailable(&format!("cannot enable controllers: {e}"));
     }
-    tracing::info!(base = %base.display(), "per-build cgroup limits enabled");
+    tracing::info!(base = %base.display(), "per-build cgroup scoping enabled");
     Some(base)
 }
 
@@ -57,7 +56,6 @@ pub fn create(base: &Path, build_id: &str, memory_max: Option<u64>) -> Option<Pa
     let dir = build_dir(base, build_id);
     let setup = || -> std::io::Result<()> {
         fs::create_dir_all(&dir)?;
-        fs::write(dir.join("pids.max"), "4096")?;
         if let Some(bytes) = memory_max {
             fs::write(dir.join("memory.max"), bytes.to_string())?;
         }

--- a/crates/tribuchet/src/worker/sandbox.rs
+++ b/crates/tribuchet/src/worker/sandbox.rs
@@ -51,8 +51,8 @@ pub struct SandboxSpec {
     /// candidates alongside outputs.
     #[serde(default)]
     pub store_inputs: Vec<String>,
-    /// Per-build cgroup; the builder enters it from pre_exec so pids/
-    /// memory limits cover the whole build, including the setup phase.
+    /// Per-build cgroup; the builder enters it from pre_exec so the
+    /// memory limit covers the whole build, including the setup phase.
     #[cfg_attr(target_os = "macos", allow(dead_code))]
     pub cgroup: Option<PathBuf>,
     /// uid-range feature: host base of a 65536-uid block mapped into

--- a/crates/tribuchet/tests/e2e.rs
+++ b/crates/tribuchet/tests/e2e.rs
@@ -729,7 +729,7 @@ fn lifecycle() {
     assert_journal(
         Node::Worker,
         "tribuchet-worker",
-        "per-build cgroup limits enabled",
+        "per-build cgroup scoping enabled",
     );
     assert_journal(Node::Hub, "tribuchet-hub", "dispatching build");
     // Inputs are imported through the worker's nix-daemon and registered as


### PR DESCRIPTION
The pids controller counts threads, and a single Nix build at full parallelism can need more than 4096: a Go build on a 384-core host spawns hundreds of compile/vet processes with a dozen threads each and failed with EAGAIN (fork rejected by the pids controller). Nix sets no per-build process cap either, so leave that to whatever encloses the worker and keep the build cgroup for memory.max and cgroup.kill teardown.