### PR TITLE
worker: preserve store objects that are symlinks inside the sandbox

### DIFF
--- a/crates/tribuchet/src/hub/relay.rs
+++ b/crates/tribuchet/src/hub/relay.rs
@@ -17,9 +17,9 @@ use tonic::Status;
 use super::state::{HubState, Job};
 use crate::chunkio::ChunkWriter;
 use crate::proto::{
-    BuildAssignment, CancelBuild, ExtraPath, HubMessage, NarTransfer, OutputNar, OutputSignature,
-    PathInfoMsg, PathOffer, ResultAck, TmpDirArchive, attach_event, hub_message, nar_transfer,
-    worker_message,
+    BuildAssignment, BuildResult, CancelBuild, ExtraPath, HubMessage, NarTransfer, OutputNar,
+    OutputSignature, PathInfoMsg, PathOffer, ResultAck, TmpDirArchive, attach_event, hub_message,
+    nar_transfer, worker_message,
 };
 
 /// How long a dispatched build may run with no attach client listening
@@ -105,21 +105,7 @@ pub(super) async fn run_job(
             // Result before ever sending MissingPaths. Pass the error
             // on to the client instead of calling it unexpected.
             worker_message::Msg::Result(res) if res.exit_code != 0 => {
-                if !(1..=255).contains(&res.exit_code) {
-                    bail!("worker sent invalid exit code {}", res.exit_code);
-                }
-                if !res.error.is_empty() {
-                    job.replay
-                        .publish(attach_event::Event::Log(
-                            format!("tribuchet worker error: {}\n", res.error).into_bytes(),
-                        ))
-                        .await;
-                }
-                super::metrics::Metrics::inc(&state.metrics.failed);
-                job.replay
-                    .publish(attach_event::Event::ExitCode(res.exit_code))
-                    .await;
-                ack_result(out_tx, job).await;
+                publish_worker_failure(state, out_tx, job, &res).await?;
                 return Ok(());
             }
             other => bail!(
@@ -696,6 +682,35 @@ async fn finish_relay(
     ack_result(out_tx, job).await;
 }
 
+/// Report a worker-side build failure to attached clients: forward
+/// the error text and exit code, count the failure, and ack so the
+/// worker can drop the build.
+async fn publish_worker_failure(
+    state: &HubState,
+    out_tx: &mpsc::Sender<Result<HubMessage, Status>>,
+    job: &Job,
+    res: &BuildResult,
+) -> Result<()> {
+    // Unix exposes only the low 8 bits to the parent; a nonzero
+    // multiple of 256 would look like success.
+    if !(1..=255).contains(&res.exit_code) {
+        bail!("worker sent invalid exit code {}", res.exit_code);
+    }
+    if !res.error.is_empty() {
+        job.replay
+            .publish(attach_event::Event::Log(
+                format!("tribuchet worker error: {}\n", res.error).into_bytes(),
+            ))
+            .await;
+    }
+    super::metrics::Metrics::inc(&state.metrics.failed);
+    job.replay
+        .publish(attach_event::Event::ExitCode(res.exit_code))
+        .await;
+    ack_result(out_tx, job).await;
+    Ok(())
+}
+
 /// Tell the worker its result (and all output NARs) arrived intact,
 /// so it can stop keeping the build for redelivery. Best effort: a
 /// lost ack only means the worker holds the build dir until its TTL.
@@ -763,23 +778,7 @@ async fn relay_build(
                     bail!("worker sent a duplicate build result");
                 }
                 if res.exit_code != 0 {
-                    // Unix exposes only the low 8 bits to the parent; a
-                    // nonzero multiple of 256 would look like success.
-                    if !(1..=255).contains(&res.exit_code) {
-                        bail!("worker sent invalid exit code {}", res.exit_code);
-                    }
-                    if !res.error.is_empty() {
-                        job.replay
-                            .publish(attach_event::Event::Log(
-                                format!("tribuchet worker error: {}\n", res.error).into_bytes(),
-                            ))
-                            .await;
-                    }
-                    super::metrics::Metrics::inc(&state.metrics.failed);
-                    job.replay
-                        .publish(attach_event::Event::ExitCode(res.exit_code))
-                        .await;
-                    ack_result(out_tx, job).await;
+                    publish_worker_failure(state, out_tx, job, &res).await?;
                     return Ok(());
                 }
                 pending = verify_set(res.outputs, &job.req.outputs)?;

--- a/crates/tribuchet/src/nar.rs
+++ b/crates/tribuchet/src/nar.rs
@@ -97,6 +97,35 @@ mod tests {
         Ok(())
     }
 
+    /// A store object that is itself a symlink round-trips as a symlink.
+    #[tokio::test]
+    async fn root_symlink_round_trip() -> Result<()> {
+        let src = tempfile::tempdir()?;
+        fs::write(src.path().join("target"), b"hello")?;
+        let link = src.path().join("link");
+        std::os::unix::fs::symlink(src.path().join("target"), &link)?;
+
+        let out = tempfile::tempdir()?;
+        let dest = out.path().join("restored");
+        round_trip_via_zstd(&link, &dest).await?;
+
+        let meta = fs::symlink_metadata(&dest)?;
+        assert!(meta.file_type().is_symlink(), "root symlink dereferenced");
+        assert_eq!(fs::read_link(&dest)?, src.path().join("target"));
+
+        let mut ours = Vec::new();
+        pack(&link, &mut ours).await?;
+        if let Ok(o) = std::process::Command::new("nix-store")
+            .arg("--dump")
+            .arg(&link)
+            .output()
+            && o.status.success()
+        {
+            assert_eq!(ours, o.stdout);
+        }
+        Ok(())
+    }
+
     /// The NAR matches nix-store --dump byte for byte when nix exists.
     #[tokio::test]
     async fn matches_nix_store_dump() -> Result<()> {

--- a/crates/tribuchet/src/worker/resume.rs
+++ b/crates/tribuchet/src/worker/resume.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::io::Read;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic;
 use std::time::{Duration, Instant};
@@ -466,49 +466,41 @@ pub(super) fn deliver(
         error: fin.error.clone(),
     })))?;
     for o in &fin.outputs {
-        let mut f = fs::File::open(&o.nar_file)?;
-        let mut buf = vec![0u8; CHUNK_SIZE];
-        loop {
-            let n = f.read(&mut buf)?;
-            if n == 0 {
-                break;
-            }
-            out_tx.blocking_send(msg(worker_message::Msg::Nar(NarTransfer {
-                build_id: build_id.into(),
-                store_path: o.scratch.clone(),
-                payload: Some(nar_transfer::Payload::ZstdNarChunk(buf[..n].to_vec())),
-                eof: false,
-            })))?;
-        }
-        out_tx.blocking_send(msg(worker_message::Msg::Nar(NarTransfer {
-            build_id: build_id.into(),
-            store_path: o.scratch.clone(),
-            payload: None,
-            eof: true,
-        })))?;
+        stream_nar(out_tx, build_id, &o.scratch, &o.nar_file)?;
     }
     for e in &fin.extras {
-        let mut f = fs::File::open(&e.nar_file)?;
-        let mut buf = vec![0u8; CHUNK_SIZE];
-        loop {
-            let n = f.read(&mut buf)?;
-            if n == 0 {
-                break;
-            }
-            out_tx.blocking_send(msg(worker_message::Msg::Nar(NarTransfer {
-                build_id: build_id.into(),
-                store_path: e.path.clone(),
-                payload: Some(nar_transfer::Payload::ZstdNarChunk(buf[..n].to_vec())),
-                eof: false,
-            })))?;
+        stream_nar(out_tx, build_id, &e.path, &e.nar_file)?;
+    }
+    Ok(())
+}
+
+/// Stream one NAR file to the hub in chunks, followed by an eof marker.
+fn stream_nar(
+    out_tx: &mpsc::Sender<WorkerMessage>,
+    build_id: &str,
+    store_path: &str,
+    nar_file: &Path,
+) -> Result<()> {
+    let mut f = fs::File::open(nar_file)?;
+    let mut buf = vec![0u8; CHUNK_SIZE];
+    loop {
+        let n = f.read(&mut buf)?;
+        if n == 0 {
+            break;
         }
         out_tx.blocking_send(msg(worker_message::Msg::Nar(NarTransfer {
             build_id: build_id.into(),
-            store_path: e.path.clone(),
-            payload: None,
-            eof: true,
+            store_path: store_path.into(),
+            payload: Some(nar_transfer::Payload::ZstdNarChunk(buf[..n].to_vec())),
+            eof: false,
         })))?;
     }
+    out_tx.blocking_send(msg(worker_message::Msg::Nar(NarTransfer {
+        build_id: build_id.into(),
+        store_path: store_path.into(),
+        payload: None,
+        eof: true,
+    })))?;
     Ok(())
 }
 

--- a/crates/tribuchet/src/worker/sandbox.rs
+++ b/crates/tribuchet/src/worker/sandbox.rs
@@ -51,6 +51,12 @@ pub struct SandboxSpec {
     /// candidates alongside outputs.
     #[serde(default)]
     pub store_inputs: Vec<String>,
+    /// Store objects that are themselves symlinks: (path inside the
+    /// sandbox, link target). Bind-mounting such a path would silently
+    /// dereference it, so they are recreated as symlinks instead.
+    #[serde(default)]
+    #[cfg_attr(target_os = "macos", allow(dead_code))]
+    pub symlink_inputs: Vec<(PathBuf, PathBuf)>,
     /// Per-build cgroup; the builder enters it from pre_exec so the
     /// memory limit covers the whole build, including the setup phase.
     #[cfg_attr(target_os = "macos", allow(dead_code))]
@@ -135,7 +141,13 @@ pub fn prepare(
         // inputs live at their real store paths (daemon import)
         binds_ro: inputs
             .iter()
+            .filter(|p| !Path::new(p).is_symlink())
             .map(|p| (PathBuf::from(p), PathBuf::from(p)))
+            .collect(),
+        symlink_inputs: inputs
+            .iter()
+            .filter(|p| Path::new(p).is_symlink())
+            .filter_map(|p| Some((PathBuf::from(p), fs::read_link(p).ok()?)))
             .collect(),
         binds_dev: Vec::new(),
         outputs: a.outputs.values().cloned().collect(),
@@ -394,6 +406,7 @@ mod tests {
             build_dir: dir.path().join("top/build"),
             binds_ro: vec![],
             store_inputs: vec![],
+            symlink_inputs: vec![],
             recursive_nix: false,
             binds_dev: vec![],
             outputs: vec![],
@@ -441,6 +454,7 @@ mod tests {
             root: dir.path().join("root"),
             build_dir: dir.path().join("top/build"),
             store_inputs: vec![],
+            symlink_inputs: vec![],
             recursive_nix: false,
             binds_ro: ["/bin", "/usr", "/lib", "/lib64", "/nix/store"]
                 .iter()
@@ -523,6 +537,7 @@ mod tests {
             binds_dev: vec![],
             outputs: vec![],
             store_inputs: vec![],
+            symlink_inputs: vec![],
             cgroup: None,
             uid_range: None,
             fod_uid: None,

--- a/crates/tribuchet/src/worker/sandbox/linux.rs
+++ b/crates/tribuchet/src/worker/sandbox/linux.rs
@@ -183,6 +183,20 @@ pub fn command(spec: &SandboxSpec) -> Result<Command> {
         }
     }
 
+    // Symlink store objects cannot be bind-mounted (the mount would
+    // resolve them); recreate them inside the private root instead.
+    for (dst, target) in &spec.symlink_inputs {
+        let link = spec.root.join(dst.strip_prefix("/").unwrap_or(dst));
+        if link.symlink_metadata().is_ok() {
+            continue;
+        }
+        if let Some(parent) = link.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        std::os::unix::fs::symlink(target, &link)
+            .with_context(|| format!("creating symlink input {}", link.display()))?;
+    }
+
     if spec.emulator.is_some() && binfmt::register_line(&spec.system).is_none() {
         anyhow::bail!("no binfmt magic known for system {}", spec.system);
     }

--- a/crates/tribuchet/tests/e2e.rs
+++ b/crates/tribuchet/tests/e2e.rs
@@ -411,6 +411,44 @@ in [ (mk "a") (mk "b") (mk "c") ]
 }
 
 #[test]
+fn build_symlink_input() {
+    // A store object that is itself a symlink must stay a symlink
+    // inside the sandbox.
+    succeed(Node::Hub, "echo symlink-target > /root/sym-target");
+    let target = succeed(Node::Hub, "nix-store --add /root/sym-target")
+        .trim()
+        .to_string();
+    succeed(Node::Hub, &format!("ln -sfn {target} /root/sym-link"));
+    let link = succeed(Node::Hub, "nix-store --add /root/sym-link")
+        .trim()
+        .to_string();
+    let expr = format!(
+        r#"let
+  bash = builtins.storePath "{bash}";
+  link = builtins.storePath "{link}";
+in derivation {{
+  name = "tt-symlink-input";
+  system = "x86_64-linux";
+  builder = bash + "/bin/bash";
+  args = [ "-c" ("test -L " + link + " && echo symlink-input-ok > $out") ];
+}}
+"#,
+        bash = bash(),
+    );
+    write_file(Node::Hub, "/root/symlink-input.nix", &expr);
+    // The path must be missing on the worker so it travels over the wire.
+    succeed(
+        Node::Worker,
+        &format!("nix-store --delete {link} 2>/dev/null || true"),
+    );
+    let out = succeed(Node::Hub, "nix-build /root/symlink-input.nix --no-out-link");
+    succeed(
+        Node::Hub,
+        &format!("grep -q symlink-input-ok {}", out.trim()),
+    );
+}
+
+#[test]
 fn build_uidrange() {
     build_grep("/etc/tt/uidrange.nix", "uid-range-ok");
 }


### PR DESCRIPTION

Inputs are staged into the sandbox with per-path bind mounts. mount(2)
resolves a symlink source, so a store object that is itself a symlink
(e.g. "ln -s $dep/bin/prog $out") shows up in the sandbox as a
regular file with the target's content, corrupting builds that inspect
such an input.

Recreate symlink store objects inside the private root instead of
bind-mounting them, matching Nix's own sandbox.
