### PR TITLE
worker: mknod sandbox device nodes instead of binding host /dev

### DIFF
--- a/crates/tribuchet/src/worker/sandbox/linux.rs
+++ b/crates/tribuchet/src/worker/sandbox/linux.rs
@@ -63,18 +63,7 @@ pub fn prepare(spec: &mut SandboxSpec) -> Result<()> {
         "127.0.0.1 localhost\n::1 localhost\n",
     )?;
 
-    for dev in ["null", "zero", "full", "random", "urandom", "tty"] {
-        let host = PathBuf::from("/dev").join(dev);
-        fs::File::create(root.join("dev").join(dev))?;
-        spec.binds_dev.push((host.clone(), host)); // dev nodes: bind, rw via node perms
-    }
-    // Nix's `kvm` system feature: pass the device through when the
-    // host has it (VM builds, NixOS tests).
-    let kvm = PathBuf::from("/dev/kvm");
-    if kvm.exists() {
-        fs::File::create(root.join("dev/kvm"))?;
-        spec.binds_dev.push((kvm.clone(), kvm));
-    }
+    populate_dev(root, &mut spec.binds_dev)?;
     for (link, target) in [
         ("dev/fd", "/proc/self/fd"),
         ("dev/stdin", "/proc/self/fd/0"),
@@ -142,6 +131,58 @@ pub fn prepare(spec: &mut SandboxSpec) -> Result<()> {
         ] {
             chown_recursive(&dir, base)?;
         }
+    }
+    Ok(())
+}
+
+/// A build whose sandbox uid 0 maps to host root (emulated builds on a
+/// root worker) could chmod/chown a bind-mounted host device node, so a
+/// worker with CAP_MKNOD creates its own nodes instead. Without the
+/// capability (rootless worker) it binds the host nodes; there the
+/// sandbox never maps to a uid owning them.
+fn populate_dev(root: &Path, binds_dev: &mut Vec<(PathBuf, PathBuf)>) -> Result<()> {
+    let mut devices = vec!["null", "zero", "full", "random", "urandom", "tty"];
+    // Nix's `kvm` system feature (VM builds, NixOS tests).
+    if Path::new("/dev/kvm").exists() {
+        devices.push("kvm");
+    }
+    let mut can_mknod = true;
+    for dev in devices {
+        let host = PathBuf::from("/dev").join(dev);
+        let target = root.join("dev").join(dev);
+        if can_mknod {
+            let rdev = stat::stat(&host)
+                .with_context(|| format!("stat {}", host.display()))?
+                .st_rdev;
+            match stat::mknod(
+                &target,
+                stat::SFlag::S_IFCHR,
+                stat::Mode::from_bits_truncate(0o666),
+                rdev,
+            ) {
+                Ok(()) => {
+                    // umask clips mknod's mode; sandbox uids need 0666.
+                    fs::set_permissions(
+                        &target,
+                        std::os::unix::fs::PermissionsExt::from_mode(0o666),
+                    )
+                    .with_context(|| format!("chmod {}", target.display()))?;
+                    continue;
+                }
+                // Bind-mounting host nodes is only safe when the sandbox
+                // cannot map to a host uid owning them; a root worker
+                // stripped of CAP_MKNOD must not fall back silently.
+                Err(Errno::EPERM) if !unistd::geteuid().is_root() => can_mknod = false,
+                Err(Errno::EPERM) => {
+                    anyhow::bail!("worker runs as root but lacks CAP_MKNOD to create device nodes")
+                }
+                Err(e) => {
+                    return Err(e).with_context(|| format!("mknod {}", target.display()));
+                }
+            }
+        }
+        fs::File::create(&target)?;
+        binds_dev.push((host.clone(), host));
     }
     Ok(())
 }

--- a/crates/tribuchet/src/worker/sandbox/linux.rs
+++ b/crates/tribuchet/src/worker/sandbox/linux.rs
@@ -458,7 +458,7 @@ struct PastaHelper {
 /// against this process once [`PastaHelper::attach`] is called
 /// (after unshare). pasta's parent exits once the namespace is
 /// configured, so waiting for the helper is the readiness barrier.
-fn fork_pasta_helper(bin: &Path) -> io::Result<PastaHelper> {
+fn fork_pasta_helper(bin: &Path, runas: Option<(u32, u32)>) -> io::Result<PastaHelper> {
     let target = unistd::getpid();
     let (req_r, req_w) = unistd::pipe().map_err(ioerr("pipe"))?;
     match unsafe { unistd::fork() }.map_err(ioerr("fork pasta helper"))? {
@@ -477,16 +477,18 @@ fn fork_pasta_helper(bin: &Path) -> io::Result<PastaHelper> {
             // services stay unreachable; outbound NAT is unaffected, so
             // builds still fetch. Host-loopback mapping is left at its
             // default (the gateway) so pasta can forward DNS to a
-            // loopback resolver. --runas 0: the build is host root
-            // (mapped to an unprivileged uid only inside its userns),
-            // so pasta must stay root to setns into its /proc/<pid>/ns.
+            // loopback resolver. pasta setns()s into the root-owned
+            // build namespaces as root; --runas (interpreted in the
+            // build userns, see nix/patches) then drops it to the
+            // sandbox uid before it processes traffic.
             let pid = target.to_string();
-            let args: Vec<CString> = [
-                bin.to_string_lossy().as_ref(),
-                "--config-net",
-                "--quiet",
-                "--runas",
-                "0",
+            let runas = runas.map(|(uid, gid)| format!("{uid}:{gid}"));
+            let bin = bin.to_string_lossy();
+            let mut args: Vec<&str> = vec![bin.as_ref(), "--config-net", "--quiet"];
+            if let Some(ids) = &runas {
+                args.extend(["--runas", ids]);
+            }
+            args.extend([
                 "--gateway",
                 PASTA_HOST_V4,
                 "--address",
@@ -512,10 +514,8 @@ fn fork_pasta_helper(bin: &Path) -> io::Result<PastaHelper> {
                 "-U",
                 "none",
                 &pid,
-            ]
-            .iter()
-            .map(|s| CString::new(*s).unwrap())
-            .collect();
+            ]);
+            let args: Vec<CString> = args.iter().map(|s| CString::new(*s).unwrap()).collect();
             drop(req_r); // do not leak the pipe into pasta
             let _ = unistd::execv(&args[0], &args);
             unsafe { libc::_exit(127) }
@@ -627,7 +627,10 @@ fn setup(p: &SetupParams) -> io::Result<()> {
         flags |= CloneFlags::CLONE_NEWNET;
     }
     let pasta_helper = match p.pasta {
-        Some(bin) if p.network => Some(fork_pasta_helper(bin)?),
+        Some(bin) if p.network => Some(fork_pasta_helper(
+            bin,
+            p.fod_uid.map(|_| (p.sandbox_uid, p.sandbox_gid)),
+        )?),
         _ => None,
     };
     if p.has_cgroup {

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,14 @@
 
         default = pkgs.callPackage ./nix/package.nix {
           craneLib = crane.mkLib pkgs;
+          # pasta patched so --runas drops UID/GID only after joining the
+          # root-owned build user namespace (patches sent to passt-dev).
+          passt = pkgs.passt.overrideAttrs (old: {
+            patches = (old.patches or [ ]) ++ [
+              ./nix/patches/0001-isolation-Drop-UID-GID-after-joining-an-existing-use.patch
+              ./nix/patches/0002-pasta-Open-netns-watch-directory-before-dropping-cre.patch
+            ];
+          });
         };
       });
 

--- a/nix/patches/0001-isolation-Drop-UID-GID-after-joining-an-existing-use.patch
+++ b/nix/patches/0001-isolation-Drop-UID-GID-after-joining-an-existing-use.patch
@@ -1,0 +1,128 @@
+From e6c6c11415999557122076867916ec806b12b675 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Sun, 12 Jul 2026 09:47:43 +0200
+Subject: [PATCH 1/2] isolation: Drop UID/GID after joining an existing user
+ namespace
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+If pasta is started as root and told to attach to an existing user
+namespace (target PID or --userns), --runas is applied before the
+target namespace is opened, so opening /proc/<pid>/ns/user fails with
+EACCES for root-owned namespaces. A supervisor that creates namespaces
+as root can therefore not have pasta attach privileged and process
+traffic unprivileged.
+
+In that case, defer setgroups()/setgid()/setuid() until after
+setns(CLONE_NEWUSER): joining gives us full capabilities in the
+namespace, so the drop still succeeds, and the UID/GID are interpreted
+as mapped inside it. Document this in the man page.
+
+Unprivileged invocations and the path creating a new user namespace
+are unchanged: there the UID must be set in the original namespace so
+that it owns the new one.
+
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ isolation.c | 50 ++++++++++++++++++++++++++++++++++++--------------
+ passt.1     |  4 ++++
+ 2 files changed, 40 insertions(+), 14 deletions(-)
+
+diff --git a/isolation.c b/isolation.c
+index bbcd23b..da6db5a 100644
+--- a/isolation.c
++++ b/isolation.c
+@@ -215,10 +215,31 @@ void isolate_initial(int argc, char **argv)
+ 	close_open_files(argc, argv);
+ }
+ 
++/**
++ * set_ugid() - Drop supplementary groups and switch to final UID/GID
++ * @uid:	User ID to run as
++ * @gid:	Group ID to run as
++ */
++static void set_ugid(uid_t uid, gid_t gid)
++{
++	if (setgroups(0, NULL)) {
++		/* If we don't have CAP_SETGID, this will EPERM */
++		if (errno != EPERM)
++			die_perror("Can't drop supplementary groups");
++	}
++
++	if (setgid(gid) != 0)
++		die_perror("Can't set GID to %u", gid);
++
++	if (setuid(uid) != 0)
++		die_perror("Can't set UID to %u", uid);
++}
++
+ /**
+  * isolate_user() - Switch to final UID/GID and move into userns
+- * @uid:	User ID to run as (in original userns)
+- * @gid:	Group ID to run as (in original userns)
++ * @uid:	User ID to run as (in original userns, or in @userns if
++ *		started privileged and joining an existing userns)
++ * @gid:	Group ID to run as (same namespace as @uid)
+  * @use_userns:	Whether to join or create a userns
+  * @userns:	userns path to enter, may be empty
+  * @mode:	Mode (passt or pasta)
+@@ -232,20 +253,15 @@ void isolate_initial(int argc, char **argv)
+ void isolate_user(uid_t uid, gid_t gid, bool use_userns, const char *userns,
+ 		  enum passt_modes mode)
+ {
++	bool drop_after_join = *userns && !geteuid();
+ 	uint64_t ns_caps = 0;
+ 
+-	/* First set our UID & GID in the original namespace */
+-	if (setgroups(0, NULL)) {
+-		/* If we don't have CAP_SETGID, this will EPERM */
+-		if (errno != EPERM)
+-			die_perror("Can't drop supplementary groups");
+-	}
+-
+-	if (setgid(gid) != 0)
+-		die_perror("Can't set GID to %u", gid);
+-
+-	if (setuid(uid) != 0)
+-		die_perror("Can't set UID to %u", uid);
++	/* Set our UID & GID in the original namespace, unless we are
++	 * privileged and joining an existing userns: its path may only
++	 * be accessible to root, so join first, then drop.
++	 */
++	if (!drop_after_join)
++		set_ugid(uid, gid);
+ 
+ 	if (*userns) { /* If given a userns, join it */
+ 		int ufd;
+@@ -264,6 +280,12 @@ void isolate_user(uid_t uid, gid_t gid, bool use_userns, const char *userns,
+ 			die_perror("Couldn't create user namespace");
+ 	}
+ 
++	/* We have full capabilities in the joined userns: drop to the
++	 * target UID/GID as mapped there.
++	 */
++	if (drop_after_join)
++		set_ugid(uid, gid);
++
+ 	/* Joining a new userns gives us full capabilities; drop the
+ 	 * ones we don't need.  With --netns-only we haven't changed
+ 	 * userns but we can drop more capabilities now than at
+diff --git a/passt.1 b/passt.1
+index 0c17454..9f2b6e8 100644
+--- a/passt.1
++++ b/passt.1
+@@ -127,6 +127,10 @@ login name and group name can be passed. This requires privileges (either
+ initial effective UID 0 or CAP_SETUID capability) to work.
+ Default is to change to user \fInobody\fR if started as root.
+ 
++For \fBpasta\fR(1), if started as root and given an existing user namespace to
++join (via a target PID or \fB\-\-userns\fR), the UID and GID are changed after
++joining that user namespace, and are interpreted as mapped inside it.
++
+ .TP
+ .BR \-h ", " \-\-help
+ Display a help message and exit.
+-- 
+2.54.0
+

--- a/nix/patches/0002-pasta-Open-netns-watch-directory-before-dropping-cre.patch
+++ b/nix/patches/0002-pasta-Open-netns-watch-directory-before-dropping-cre.patch
@@ -1,0 +1,153 @@
+From f129d7fb4cbf535b776c42f3627e343afd50f710 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Sun, 12 Jul 2026 11:08:43 +0200
+Subject: [PATCH 2/2] pasta: Open netns watch directory before dropping
+ credentials
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+pasta_netns_quit_init() opens the directory containing the target
+netns (e.g. /proc/<pid>/ns) to watch for its removal. With --runas now
+applied before this point when joining an existing user namespace, the
+open fails with EACCES if the directory is only accessible to the
+original user.
+
+Open the directory before isolate_user(), keep the descriptor in the
+context and use it from pasta_netns_quit_init().
+
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ conf.c  |  3 +++
+ passt.c |  2 +-
+ passt.h |  2 ++
+ pasta.c | 39 ++++++++++++++++++++++++++++-----------
+ pasta.h |  1 +
+ 5 files changed, 35 insertions(+), 12 deletions(-)
+
+diff --git a/conf.c b/conf.c
+index 66b9e63..6df4e1d 100644
+--- a/conf.c
++++ b/conf.c
+@@ -2073,6 +2073,9 @@ void conf(struct ctx *c, int argc, char **argv)
+ 
+ 	conf_open_files(c);	/* Before any possible setuid() / setgid() */
+ 
++	if (c->mode == MODE_PASTA && *netns)
++		pasta_netns_quit_prepare(c, netns);
++
+ 	isolate_user(uid, gid, !netns_only, userns, c->mode);
+ 
+ 	if (c->no_icmp)
+diff --git a/passt.c b/passt.c
+index 31fbb75..bc5a5c8 100644
+--- a/passt.c
++++ b/passt.c
+@@ -261,7 +261,7 @@ int main(int argc, char **argv)
+ 	isolate_initial(argc, argv);
+ 
+ 	c.pasta_netns_fd = c.fd_tap = c.pidfile_fd = -1;
+-	c.device_state_fd = -1;
++	c.device_state_fd = c.netns_dir_fd = -1;
+ 
+ 	sigemptyset(&sa.sa_mask);
+ 	sa.sa_flags = 0;
+diff --git a/passt.h b/passt.h
+index 0075eb4..26519b3 100644
+--- a/passt.h
++++ b/passt.h
+@@ -200,6 +200,7 @@ struct ip6_ctx {
+  * @no_netns_quit:	In pasta mode, don't exit if fs-bound namespace is gone
+  * @netns_base:		Base name for fs-bound namespace, if any, in pasta mode
+  * @netns_dir:		Directory of fs-bound namespace, if any, in pasta mode
++ * @netns_dir_fd:	Descriptor for @netns_dir, opened before credential drop
+  * @epollfd:		File descriptor for epoll instance
+  * @fd_tap_listen:	File descriptor for listening AF_UNIX socket, if any
+  * @fd_tap:		AF_UNIX socket, tuntap device, or pre-opened socket
+@@ -267,6 +268,7 @@ struct ctx {
+ 	int no_netns_quit;
+ 	char netns_base[PATH_MAX];
+ 	char netns_dir[PATH_MAX];
++	int netns_dir_fd;
+ 
+ 	int epollfd;
+ 	int fd_tap_listen;
+diff --git a/pasta.c b/pasta.c
+index 687406b..981cf82 100644
+--- a/pasta.c
++++ b/pasta.c
+@@ -133,6 +133,31 @@ static int ns_check(void *arg)
+ 
+ }
+ 
++/**
++ * pasta_netns_quit_prepare() - Open netns watch directory before isolation
++ * @c:		Execution context
++ * @netns:	network namespace path
++ *
++ * The directory (e.g. /proc/<pid>/ns) may only be accessible with our initial
++ * credentials, so open it before isolate_user().
++ */
++void pasta_netns_quit_prepare(struct ctx *c, const char *netns)
++{
++	char buf[PATH_MAX] = { 0 };
++
++	if (c->no_netns_quit)
++		return;
++
++	strncpy(buf, netns, PATH_MAX - 1);
++	strncpy(c->netns_base, basename(buf), PATH_MAX - 1);
++	strncpy(buf, netns, PATH_MAX - 1);
++	strncpy(c->netns_dir, dirname(buf), PATH_MAX - 1);
++
++	c->netns_dir_fd = open(c->netns_dir, O_CLOEXEC | O_RDONLY);
++	if (c->netns_dir_fd < 0)
++		die("netns dir open: %s, exiting", strerror_(errno));
++}
++
+ /**
+  * pasta_open_ns() - Open network namespace descriptors
+  * @c:		Execution context
+@@ -154,15 +179,6 @@ void pasta_open_ns(struct ctx *c, const char *netns)
+ 
+ 	if (c->pasta_netns_fd < 0)
+ 		die_perror("Couldn't switch to pasta namespaces");
+-
+-	if (!c->no_netns_quit) {
+-		char buf[PATH_MAX] = { 0 };
+-
+-		strncpy(buf, netns, PATH_MAX - 1);
+-		strncpy(c->netns_base, basename(buf), PATH_MAX - 1);
+-		strncpy(buf, netns, PATH_MAX - 1);
+-		strncpy(c->netns_dir, dirname(buf), PATH_MAX - 1);
+-	}
+ }
+ 
+ /**
+@@ -454,8 +470,9 @@ void pasta_netns_quit_init(const struct ctx *c)
+ 	if (c->mode != MODE_PASTA || c->no_netns_quit || !*c->netns_base)
+ 		return;
+ 
+-	if ((dir_fd = open(c->netns_dir, O_CLOEXEC | O_RDONLY)) < 0)
+-		die("netns dir open: %s, exiting", strerror_(errno));
++	dir_fd = c->netns_dir_fd;
++	if (dir_fd < 0)
++		die("netns watch directory not open, exiting");
+ 
+ 	if (fstatfs(dir_fd, &s)          || s.f_type == DEVPTS_SUPER_MAGIC ||
+ 	    s.f_type == PROC_SUPER_MAGIC || s.f_type == SYSFS_MAGIC)
+diff --git a/pasta.h b/pasta.h
+index 4b063d1..6ae7e23 100644
+--- a/pasta.h
++++ b/pasta.h
+@@ -8,6 +8,7 @@
+ 
+ extern int pasta_child_pid;
+ 
++void pasta_netns_quit_prepare(struct ctx *c, const char *netns);
+ void pasta_open_ns(struct ctx *c, const char *netns);
+ void pasta_start_ns(struct ctx *c, uid_t uid, gid_t gid,
+ 		    int argc, char *argv[]);
+-- 
+2.54.0
+


### PR DESCRIPTION

Sandbox /dev/null etc. were rw bind mounts of the host device nodes.
Emulated builds on a root worker map sandbox uid 0 to host root, so a
build could chmod the real /dev/null; two builders ended up with an
unwritable 0555 /dev/null.

Create fresh nodes with mknod when the worker has CAP_MKNOD. Rootless
workers keep the bind fallback, safe because their sandbox never maps
to a uid owning the host nodes; a root worker stripped of CAP_MKNOD
fails loudly instead of falling back.


