### PR TITLE
Trim tokio features and modernize WATCHDOG_PID check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,7 +2032,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ toml = "1.1"
 sha2 = "0.11"
 tar = "0.4"
 tempfile = "3"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "net", "io-util", "signal"] }
 tokio-stream = "0.1"
 tonic = { version = "0.14", features = ["tls-ring"] }
 tonic-prost = "0.14"

--- a/crates/tribuchet/src/sd.rs
+++ b/crates/tribuchet/src/sd.rs
@@ -154,7 +154,7 @@ pub fn spawn_watchdog() {
         .and_then(|v| v.parse::<u64>().ok())
         .map(std::time::Duration::from_micros)
         .filter(|_| {
-            std::env::var("WATCHDOG_PID").map_or(true, |p| {
+            std::env::var("WATCHDOG_PID").ok().is_none_or(|p| {
                 p == std::process::id().to_string()
                     || p == nix::unistd::getppid().as_raw().to_string()
             })


### PR DESCRIPTION
- tokio: replace "full" with the feature set we actually use (faster clean builds)
- sd: use is_none_or for the WATCHDOG_PID check