### PR TITLE
ci: update hestia action to stable v2.0.0 release

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,10 +81,7 @@ jobs:
           extra-conf: ${{ env.NIX_EXTRA_CONF }}
 
       # GHA-cache layer over cache.thalheim.io.
-      - uses: Mic92/hestia-beta@v2.0.0-beta.1
-        with:
-          version: v2.0.0-beta.1
-
+      - uses: Mic92/hestia@v2.0.0
       - uses: tailscale/github-action@v4
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
@@ -147,10 +144,7 @@ jobs:
           extra-conf: ${{ env.NIX_EXTRA_CONF }}
 
       # GHA-cache layer over cache.thalheim.io.
-      - uses: Mic92/hestia-beta@v2.0.0-beta.1
-        with:
-          version: v2.0.0-beta.1
-
+      - uses: Mic92/hestia@v2.0.0
       - uses: tailscale/github-action@v4
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc
       # Installs the released hestia binary and captures the cache API
       # tokens GC needs (HESTIA_BIN points at the binary).
-      - uses: Mic92/hestia-beta@v2.0.0-beta.1
+      - uses: Mic92/hestia@v2.0.0
         with:
           version: v2.0.0-beta.1
       - run: "$HESTIA_BIN gc ${{ inputs.dry-run && '--dry-run' || '' }}"


### PR DESCRIPTION
The beta repo has no newer tags; switch to the stable Mic92/hestia
repository which now provides the v2.0.0 release.
