### PR TITLE
worker: own input dedup and re-request stale inputs instead of failing

### DIFF
--- a/.github/scripts/e2e/run.py
+++ b/.github/scripts/e2e/run.py
@@ -23,8 +23,10 @@ BIN = REPO / "result" / "bin" / "tribuchet"
 HUB_LOG = REPO / "hub.log"
 WORKER_LOG = REPO / "worker.log"
 AGENT_LOG = REPO / "agent.log"
-AGENT_SOCKET = REPO / "agent.sock"
-AGENT_STATE = REPO / "agent-state"
+AGENT_SOCKET = Path("/var/lib/tribuchet-agent/agent.sock")
+AGENT_STATE = Path("/var/lib/tribuchet-agent/state")
+# Same default uid block as the NixOS module.
+AGENT_UID_BASE = 1325400064
 
 
 def run(cmd: list[str], **kw: object) -> subprocess.CompletedProcess[str]:
@@ -266,11 +268,12 @@ def job_conclusion(name: str) -> str | None:
     return None
 
 
-def start_agent(*, as_root: bool) -> None:
-    """One build agent in development mode (self-bound socket, no
-    dedicated uid block): builds run as the agent's own uid, which is
-    the worker's uid too."""
+def start_agent(worker_uid: int) -> None:
+    """One build agent as root (which has the capabilities the agent's
+    user namespaces need) with a self-bound socket."""
+    run(["sudo", "mkdir", "-p", str(AGENT_STATE)])
     agent_cmd = [
+        "sudo",
         "RUST_LOG=info",
         str(BIN),
         "agent",
@@ -278,9 +281,12 @@ def start_agent(*, as_root: bool) -> None:
         str(AGENT_SOCKET),
         "--state-dir",
         str(AGENT_STATE),
+        "--worker-uid",
+        str(worker_uid),
     ]
-    prefix = ["sudo"] if as_root else ["env"]
-    proc = spawn_daemon([*prefix, *agent_cmd], AGENT_LOG)
+    if sys.platform == "linux":
+        agent_cmd += ["--uid-base", str(AGENT_UID_BASE)]
+    proc = spawn_daemon(agent_cmd, AGENT_LOG)
     wait_for(
         lambda: AGENT_SOCKET.exists() or proc.poll() is not None,
         timeout=30,
@@ -289,6 +295,8 @@ def start_agent(*, as_root: bool) -> None:
     if proc.poll() is not None:
         sys.stderr.write(AGENT_LOG.read_text())
         raise SystemExit("agent exited")
+    # The unprivileged worker must connect to the root-owned socket.
+    run(["sudo", "chmod", "666", str(AGENT_SOCKET)])
 
 
 def worker_run(hub_ip: str) -> None:
@@ -314,21 +322,20 @@ def worker_run(hub_ip: str) -> None:
         "/etc/tribuchet/worker.toml",
     ]
     if sys.platform == "linux":
-        # The Linux worker and its agent run unprivileged as the runner
-        # user. Importing inputs through nix-daemon without signatures
-        # needs a trusted user.
+        # The worker runs unprivileged; builds run in the root agent's
+        # user namespaces. Importing inputs through nix-daemon without
+        # signatures needs a trusted user.
         user = out(["id", "-un"])
         run(["sudo", "chown", user, "/var/lib/tribuchet"])
         # Ubuntu 24.04 blocks unprivileged user namespaces by default
         run(["sudo", "sysctl", "-w", "kernel.apparmor_restrict_unprivileged_userns=0"])
         sudo_write("/etc/nix/nix.conf", f"trusted-users = root {user}\n", append=True)
         run(["sudo", "systemctl", "restart", "nix-daemon"])
-        start_agent(as_root=False)
+        start_agent(worker_uid=os.getuid())
         proc = spawn_daemon(["env", *worker_cmd], WORKER_LOG)
     else:
-        # macOS: root for the Seatbelt sandbox and nix-daemon trust; the
-        # agent must share the worker's uid, so it runs as root too.
-        start_agent(as_root=True)
+        # macOS: worker and agent run as root (Seatbelt, nix-daemon trust).
+        start_agent(worker_uid=0)
         proc = spawn_daemon(["sudo", *worker_cmd], WORKER_LOG)
 
     def finished() -> bool:

--- a/.github/scripts/e2e/run.py
+++ b/.github/scripts/e2e/run.py
@@ -20,10 +20,11 @@ from typing import Any
 
 REPO = Path(__file__).resolve().parents[3]
 BIN = REPO / "result" / "bin" / "tribuchet"
-SANDBOXD_BIN = REPO / "result" / "bin" / "tribuchet-sandboxd"
 HUB_LOG = REPO / "hub.log"
 WORKER_LOG = REPO / "worker.log"
-SANDBOXD_LOG = REPO / "sandboxd.log"
+AGENT_LOG = REPO / "agent.log"
+AGENT_SOCKET = REPO / "agent.sock"
+AGENT_STATE = REPO / "agent-state"
 
 
 def run(cmd: list[str], **kw: object) -> subprocess.CompletedProcess[str]:
@@ -265,28 +266,29 @@ def job_conclusion(name: str) -> str | None:
     return None
 
 
-def start_sandboxd(user: str) -> None:
-    """Root daemon leasing per-build sandboxes to the unprivileged worker."""
-    proc = spawn_daemon(
-        [
-            "sudo",
-            "RUST_LOG=info",
-            str(SANDBOXD_BIN),
-            "--worker-user",
-            user,
-        ],
-        SANDBOXD_LOG,
-    )
+def start_agent(*, as_root: bool) -> None:
+    """One build agent in development mode (self-bound socket, no
+    dedicated uid block): builds run as the agent's own uid, which is
+    the worker's uid too."""
+    agent_cmd = [
+        "RUST_LOG=info",
+        str(BIN),
+        "agent",
+        "--socket",
+        str(AGENT_SOCKET),
+        "--state-dir",
+        str(AGENT_STATE),
+    ]
+    prefix = ["sudo"] if as_root else ["env"]
+    proc = spawn_daemon([*prefix, *agent_cmd], AGENT_LOG)
     wait_for(
-        lambda: (
-            Path("/run/tribuchet-sandboxd.sock").exists() or proc.poll() is not None
-        ),
+        lambda: AGENT_SOCKET.exists() or proc.poll() is not None,
         timeout=30,
-        what="sandboxd to start",
+        what="agent to start",
     )
     if proc.poll() is not None:
-        sys.stderr.write(SANDBOXD_LOG.read_text())
-        raise SystemExit("sandboxd exited")
+        sys.stderr.write(AGENT_LOG.read_text())
+        raise SystemExit("agent exited")
 
 
 def worker_run(hub_ip: str) -> None:
@@ -299,6 +301,7 @@ def worker_run(hub_ip: str) -> None:
             auth = "tailscale"
             max-jobs = 1
             state-dir = "/var/lib/tribuchet"
+            agent-sockets = ["{AGENT_SOCKET}"]
             """
         ),
     )
@@ -311,20 +314,21 @@ def worker_run(hub_ip: str) -> None:
         "/etc/tribuchet/worker.toml",
     ]
     if sys.platform == "linux":
-        # The Linux worker is unprivileged: it runs as the runner user and
-        # leases each build's user namespace and cgroup from sandboxd.
-        # Importing inputs through nix-daemon without signatures needs a
-        # trusted user.
+        # The Linux worker and its agent run unprivileged as the runner
+        # user. Importing inputs through nix-daemon without signatures
+        # needs a trusted user.
         user = out(["id", "-un"])
         run(["sudo", "chown", user, "/var/lib/tribuchet"])
         # Ubuntu 24.04 blocks unprivileged user namespaces by default
         run(["sudo", "sysctl", "-w", "kernel.apparmor_restrict_unprivileged_userns=0"])
         sudo_write("/etc/nix/nix.conf", f"trusted-users = root {user}\n", append=True)
         run(["sudo", "systemctl", "restart", "nix-daemon"])
-        start_sandboxd(user)
+        start_agent(as_root=False)
         proc = spawn_daemon(["env", *worker_cmd], WORKER_LOG)
     else:
-        # macOS: root for the Seatbelt sandbox and nix-daemon trust.
+        # macOS: root for the Seatbelt sandbox and nix-daemon trust; the
+        # agent must share the worker's uid, so it runs as root too.
+        start_agent(as_root=True)
         proc = spawn_daemon(["sudo", *worker_cmd], WORKER_LOG)
 
     def finished() -> bool:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -168,4 +168,4 @@ jobs:
       - run: python3 .github/scripts/e2e/run.py worker --hub-ip "$HUB_TS_IP"
 
       - if: always()
-        run: cat worker.log sandboxd.log 2>/dev/null || true
+        run: cat worker.log agent.log 2>/dev/null || true

--- a/crates/sandbox-proto/src/framing.rs
+++ b/crates/sandbox-proto/src/framing.rs
@@ -172,27 +172,34 @@ mod tests {
 
     /// A message larger than one read buffer must be reassembled, and
     /// reading it must not consume the already-queued next message.
+    /// Sent from a thread: it exceeds macOS's socket buffer.
     #[test]
     fn large_message_leaves_the_next_one_intact() {
         let (a, b) = UnixStream::pair().unwrap();
+        let build_id = "x".repeat(64 * 1024);
         let request = AdoptRequest {
-            build_id: "x".repeat(64 * 1024),
+            build_id: build_id.clone(),
         };
-        send_call(&a, METHOD_ADOPT, &request, &[]).unwrap();
-        send_reply(
-            &a,
-            &StartReply {
-                pid: 7,
-                scratch_dir: "/scratch/next".into(),
-            },
-            &[],
-        )
-        .unwrap();
+        let sender = {
+            std::thread::spawn(move || {
+                send_call(&a, METHOD_ADOPT, &request, &[]).unwrap();
+                send_reply(
+                    &a,
+                    &StartReply {
+                        pid: 7,
+                        scratch_dir: "/scratch/next".into(),
+                    },
+                    &[],
+                )
+                .unwrap();
+            })
+        };
 
         let (_, received, _): (_, AdoptRequest, _) = recv_call(&b).unwrap();
-        assert_eq!(received, request);
+        assert_eq!(received.build_id, build_id);
         let (reply, _): (StartReply, _) = recv_reply(&b).unwrap();
         assert_eq!(reply.scratch_dir, "/scratch/next");
+        sender.join().unwrap();
     }
 
     #[test]

--- a/crates/tribuchet/proto/tribuchet.proto
+++ b/crates/tribuchet/proto/tribuchet.proto
@@ -53,7 +53,14 @@ message HubMessage {
     // The hub received and verified the result and output NARs; the
     // worker keeps the build for redelivery until this arrives.
     ResultAck result_ack = 7;
+    // Ends an input resend round; the worker re-checks its inputs
+    // and either starts the build or asks again.
+    StagingComplete staging_complete = 8;
   }
+}
+
+message StagingComplete {
+  string build_id = 1;
 }
 
 message ResultAck {

--- a/crates/tribuchet/src/hub/relay.rs
+++ b/crates/tribuchet/src/hub/relay.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet};
 use std::io::{self, Write};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
@@ -15,35 +15,27 @@ use tonic::Status;
 use super::state::{HubState, Job};
 use crate::proto::{
     BuildAssignment, BuildResult, CancelBuild, ExtraPath, HubMessage, NarTransfer, OutputNar,
-    OutputSignature, PathInfoMsg, PathOffer, ResultAck, TmpDirArchive, attach_event, hub_message,
-    nar_transfer, worker_message,
+    OutputSignature, PathInfoMsg, PathOffer, ResultAck, StagingComplete, TmpDirArchive,
+    attach_event, hub_message, nar_transfer, worker_message,
 };
 
 /// How long a dispatched build may run with no attach client listening
 /// before the hub cancels it on the worker.
 const CANCEL_GRACE: Duration = Duration::from_secs(10);
 
+/// Cap on input resend rounds per build.
+const MAX_RESEND_ROUNDS: u32 = 3;
+
 /// Per-worker-session staging state: one build's inputs stream at a
-/// time, and paths already streamed this session are not re-sent.
+/// time. Dedup of shared inputs happens on the worker.
 pub(super) struct WorkerStaging {
     permits: tokio::sync::Semaphore,
-    streamed: Mutex<HashSet<String>>,
 }
 
 impl WorkerStaging {
     pub(super) fn new() -> Self {
         Self {
             permits: tokio::sync::Semaphore::new(1),
-            streamed: Mutex::default(),
-        }
-    }
-
-    /// Forget paths a build streamed but may not have imported (it
-    /// failed or the session errored), so a later build re-streams them.
-    fn unstage(&self, paths: &[String]) {
-        let mut set = self.streamed.lock().unwrap();
-        for p in paths {
-            set.remove(p);
         }
     }
 }
@@ -98,7 +90,7 @@ pub(super) async fn run_job(
             // restart); skip staging, its result arrives like any other.
             worker_message::Msg::Resumed(_) => {
                 tracing::info!(id = job.id, "worker resumed an in-flight build");
-                return relay_build(state, job, vkey, out_tx, &mut in_rx)
+                return relay_build(state, job, vkey, out_tx, &mut in_rx, &staging)
                     .await
                     .map(|_| ());
             }
@@ -108,21 +100,7 @@ pub(super) async fn run_job(
                 job.replay.publish(attach_event::Event::Log(l.data)).await;
             }
             worker_message::Msg::MissingPaths(m) => {
-                // Only ever pack paths we offered: anything else would let
-                // a compromised worker read arbitrary host files. Dedupe,
-                // so a repeated entry cannot amplify pack work either.
-                let offered: HashSet<&String> = req.input_paths.iter().collect();
-                let mut missing = Vec::new();
-                let mut seen = HashSet::new();
-                for p in m.store_paths {
-                    if !offered.contains(&p) {
-                        bail!("worker requested unoffered path {p}");
-                    }
-                    if seen.insert(p.clone()) {
-                        missing.push(p);
-                    }
-                }
-                break missing;
+                break validate_missing(&req.input_paths, m.store_paths)?;
             }
             // Staging failed worker-side (assignment validation, its
             // nix-daemon unreachable, ...): the worker reports it as a
@@ -145,27 +123,37 @@ pub(super) async fn run_job(
         "input path negotiation done"
     );
 
-    let new_paths = stage_inputs(state, job, out_tx, &staging, &missing).await?;
-    let res = relay_build(state, job, vkey, out_tx, &mut in_rx).await;
-    if !matches!(res, Ok(true)) {
-        staging.unstage(&new_paths);
+    stage_inputs(state, job, out_tx, &staging, &missing).await?;
+    relay_build(state, job, vkey, out_tx, &mut in_rx, &staging)
+        .await
+        .map(|_| ())
+}
+
+/// Reject paths we never offered and dedupe the rest.
+fn validate_missing(offered_paths: &[String], requested: Vec<String>) -> Result<Vec<String>> {
+    let offered: HashSet<&String> = offered_paths.iter().collect();
+    let mut missing = Vec::new();
+    let mut seen = HashSet::new();
+    for p in requested {
+        if !offered.contains(&p) {
+            bail!("worker requested unoffered path {p}");
+        }
+        if seen.insert(p.clone()) {
+            missing.push(p);
+        }
     }
-    res.map(|_| ())
+    Ok(missing)
 }
 
 /// Stream this build's missing inputs and tmp dir under the session's
-/// staging permit; returns the paths newly streamed. Paths an earlier
-/// build already streamed are skipped: staging phases are serialized
-/// and the worker imports NARs in stream order, so those imports are
-/// committed before this build's inputs arrive. The worker re-checks
-/// skipped paths when its staging completes.
+/// staging permit.
 async fn stage_inputs(
     state: &HubState,
     job: &Job,
     out_tx: &mpsc::Sender<Result<HubMessage, Status>>,
     staging: &WorkerStaging,
     missing: &[String],
-) -> Result<Vec<String>> {
+) -> Result<()> {
     // Serialize only the import: negotiation before this is read-only
     // on the worker store, so it runs in parallel (bounded by
     // RequestJob credits) instead of gating throughput on its
@@ -175,45 +163,49 @@ async fn stage_inputs(
         .acquire()
         .await
         .expect("staging semaphore closed");
-    let new_paths = select_unstreamed(&staging.streamed, missing);
-    if new_paths.len() < missing.len() {
-        tracing::info!(
-            id = job.id,
-            skipped = missing.len() - new_paths.len(),
-            "inputs already streamed earlier in this worker session"
-        );
-    }
-    let res = async {
-        // The worker imports missing inputs through its Nix daemon, which
-        // needs the full ValidPathInfo; ask the local nix-daemon for it.
-        // AddToStoreNar also needs a path's references valid first, and
-        // Nix's order is not topological, so reorder references before
-        // referrers.
-        let infos = order_by_references(query_path_infos(&state.daemon_pool, &new_paths).await?);
-        for mut info in infos {
-            let path = info.store_path.clone();
-            info.build_id = job.id.clone();
-            send(out_tx, hub_message::Msg::PathInfo(info)).await?;
-            stream_store_path(&job.id, &path, out_tx).await?;
-        }
-        stream_tmp_dir(&job.id, &job.tmp_dir_tar, out_tx).await
-    }
-    .await;
-    if res.is_err() {
-        staging.unstage(&new_paths);
-    }
-    res.map(|()| new_paths)
+    stream_inputs(state, job, out_tx, missing).await?;
+    stream_tmp_dir(&job.id, &job.tmp_dir_tar, out_tx).await
 }
 
-/// Record `missing` in the session's streamed set; return the paths
-/// not streamed before.
-fn select_unstreamed(staged: &Mutex<HashSet<String>>, missing: &[String]) -> Vec<String> {
-    let mut set = staged.lock().unwrap();
-    missing
-        .iter()
-        .filter(|p| set.insert((*p).clone()))
-        .cloned()
-        .collect()
+/// Stream inputs re-requested after staging, then send StagingComplete.
+async fn restage_inputs(
+    state: &HubState,
+    job: &Job,
+    out_tx: &mpsc::Sender<Result<HubMessage, Status>>,
+    staging: &WorkerStaging,
+    missing: &[String],
+) -> Result<()> {
+    let _permit = staging
+        .permits
+        .acquire()
+        .await
+        .expect("staging semaphore closed");
+    stream_inputs(state, job, out_tx, missing).await?;
+    send(
+        out_tx,
+        hub_message::Msg::StagingComplete(StagingComplete {
+            build_id: job.id.clone(),
+        }),
+    )
+    .await
+}
+
+/// Stream PathInfo + NAR for each path, references before referrers
+/// (the worker's daemon import needs the references valid first).
+async fn stream_inputs(
+    state: &HubState,
+    job: &Job,
+    out_tx: &mpsc::Sender<Result<HubMessage, Status>>,
+    paths: &[String],
+) -> Result<()> {
+    let infos = order_by_references(query_path_infos(&state.daemon_pool, paths).await?);
+    for mut info in infos {
+        let path = info.store_path.clone();
+        info.build_id = job.id.clone();
+        send(out_tx, hub_message::Msg::PathInfo(info)).await?;
+        stream_store_path(&job.id, &path, out_tx).await?;
+    }
+    Ok(())
 }
 
 /// Log/error-safe name of a worker message variant. The messages embed
@@ -692,10 +684,12 @@ async fn relay_build(
     vkey: &PublicKey,
     out_tx: &mpsc::Sender<Result<HubMessage, Status>>,
     in_rx: &mut mpsc::Receiver<worker_message::Msg>,
+    staging: &WorkerStaging,
 ) -> Result<bool> {
     let mut pending: HashMap<String, OutputVerify> = HashMap::new();
     let mut extras: HashMap<String, ExtraImport> = HashMap::new();
     let mut awaiting_outputs = false;
+    let mut resend_rounds = 0;
     let mut abandoned_since: Option<Instant> = None;
     let mut cancel_sent = false;
     // An interval, not a per-iteration sleep: a build that logs
@@ -733,6 +727,22 @@ async fn relay_build(
         match m {
             worker_message::Msg::Log(l) => {
                 job.replay.publish(attach_event::Event::Log(l.data)).await;
+            }
+            // Inputs the worker deferred to another build's import
+            // that never became valid: re-stream them.
+            worker_message::Msg::MissingPaths(m) if !awaiting_outputs => {
+                resend_rounds += 1;
+                if resend_rounds > MAX_RESEND_ROUNDS {
+                    bail!("worker requested input re-sends more than {MAX_RESEND_ROUNDS} times");
+                }
+                let missing = validate_missing(&job.req.input_paths, m.store_paths)?;
+                tracing::info!(
+                    id = job.id,
+                    round = resend_rounds,
+                    count = missing.len(),
+                    "re-streaming inputs the worker reported missing after staging"
+                );
+                restage_inputs(state, job, out_tx, staging, &missing).await?;
             }
             worker_message::Msg::Result(res) => {
                 if awaiting_outputs {
@@ -797,22 +807,15 @@ mod tests {
     }
 
     #[test]
-    fn already_streamed_paths_are_skipped_and_reset_on_failure() {
-        let staged = Mutex::new(HashSet::new());
-        let a = "/nix/store/aaa".to_string();
-        let b = "/nix/store/bbb".to_string();
-        assert_eq!(
-            select_unstreamed(&staged, &[a.clone(), b.clone()]),
-            vec![a.clone(), b.clone()]
-        );
-        // A later build sharing an input streams only its delta.
-        assert_eq!(
-            select_unstreamed(&staged, &[a.clone(), b.clone()]),
-            Vec::<String>::new()
-        );
-        // A failed build's paths are removed and get streamed again.
-        staged.lock().unwrap().remove(&a);
-        assert_eq!(select_unstreamed(&staged, &[a.clone(), b]), vec![a]);
+    fn missing_paths_are_validated_against_the_offer() {
+        let offered = vec!["/nix/store/aaa".to_string(), "/nix/store/bbb".to_string()];
+        let dup = vec![
+            "/nix/store/aaa".to_string(),
+            "/nix/store/aaa".to_string(),
+            "/nix/store/bbb".to_string(),
+        ];
+        assert_eq!(validate_missing(&offered, dup).unwrap(), offered);
+        assert!(validate_missing(&offered, vec!["/etc/shadow".into()]).is_err());
     }
 
     #[test]

--- a/crates/tribuchet/src/worker.rs
+++ b/crates/tribuchet/src/worker.rs
@@ -34,7 +34,7 @@ use tokio::sync::{Semaphore, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::transport::{Certificate, ClientTlsConfig, Endpoint, Identity};
 
-use build::{ActiveBuild, validate_assignment};
+use build::{ActiveBuild, StagingStatus, validate_assignment};
 use caps::{host_system, system_caps};
 use logtail::spawn_log_tail;
 use resume::{
@@ -83,6 +83,9 @@ struct WorkerCtx {
     /// abort them. Keyed like the registry, since a resumed build's
     /// build_id changes while it runs.
     cancelled: Mutex<HashSet<String>>,
+    /// Input paths a build is currently importing. Other builds defer
+    /// to that import instead of requesting the same NAR again.
+    staging_inflight: Mutex<HashSet<String>>,
 }
 
 impl WorkerCtx {
@@ -317,6 +320,7 @@ async fn run_async(opts: WorkerConfig) -> Result<()> {
         secret_paths: vec![opts.key.clone(), opts.state_dir.join("signing.key")],
         slots: Arc::new(Semaphore::new(opts.max_jobs.max(1) as usize)),
         cancelled: Mutex::new(HashSet::new()),
+        staging_inflight: Mutex::new(HashSet::new()),
         resumable: Mutex::new(HashMap::new()),
         emulators,
         fod_isolation,
@@ -533,14 +537,24 @@ async fn session_loop(
             hub_message::Msg::TmpDir(t) => {
                 let id = t.build_id.clone();
                 if let Some(build) = active.get_mut(&id) {
-                    match build.feed_tmp_dir(t).await {
-                        Err(e) => abort_active(active, &id, out_tx, &e).await?,
-                        Ok(false) => {}
-                        Ok(true) => {
-                            let build = active.remove(&id).unwrap();
-                            launch_build(ctx, build, out_tx, signing_key, build_timeout);
-                        }
-                    }
+                    let res = build.feed_tmp_dir(t).await;
+                    advance_staging(active, &id, res, ctx, out_tx, signing_key, build_timeout)
+                        .await?;
+                }
+            }
+            hub_message::Msg::StagingComplete(s) => {
+                if let Some(build) = active.get_mut(&s.build_id) {
+                    let res = build.complete_staging().await;
+                    advance_staging(
+                        active,
+                        &s.build_id,
+                        res,
+                        ctx,
+                        out_tx,
+                        signing_key,
+                        build_timeout,
+                    )
+                    .await?;
                 }
             }
             hub_message::Msg::PathInfo(pi) => {
@@ -579,6 +593,40 @@ async fn session_loop(
             }
         }
     }
+}
+
+/// Act on a staging step: launch, request an input resend, or abort.
+async fn advance_staging(
+    active: &mut HashMap<String, ActiveBuild>,
+    id: &str,
+    res: Result<StagingStatus>,
+    ctx: &Arc<WorkerCtx>,
+    out_tx: &mpsc::Sender<WorkerMessage>,
+    signing_key: &Arc<SecretKey>,
+    build_timeout: Duration,
+) -> Result<()> {
+    match res {
+        Err(e) => abort_active(active, id, out_tx, &e).await?,
+        Ok(StagingStatus::InProgress) => {}
+        Ok(StagingStatus::Ready) => {
+            let build = active.remove(id).unwrap();
+            launch_build(ctx, build, out_tx, signing_key, build_timeout);
+        }
+        Ok(StagingStatus::NeedResend(paths)) => {
+            tracing::info!(
+                id,
+                count = paths.len(),
+                "re-requesting inputs another build failed to import"
+            );
+            out_tx
+                .send(msg(worker_message::Msg::MissingPaths(MissingPaths {
+                    build_id: id.to_string(),
+                    store_paths: paths,
+                })))
+                .await?;
+        }
+    }
+    Ok(())
 }
 
 /// Register a fully-staged build as resumable and run it on a blocking

--- a/crates/tribuchet/src/worker/build.rs
+++ b/crates/tribuchet/src/worker/build.rs
@@ -1,6 +1,6 @@
 //! One build on this worker: input staging, sandbox execution, output packing.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::io::{self, Write};
 use std::os::fd::{AsRawFd, OwnedFd};
@@ -27,6 +27,19 @@ use crate::tmptar::unpack_tmp_dir_archive;
 /// Cap on a single NAR transfer in either direction; a `truncate -s 1P
 /// $out` build would otherwise tie up the worker and fill its disk.
 const MAX_NAR_BYTES: u64 = 64 * 1024 * 1024 * 1024;
+
+/// Cap on input re-request rounds; the set shrinks each round, so a
+/// hub that cannot deliver fails the build instead of looping.
+const MAX_RESEND_ROUNDS: u8 = 3;
+
+/// Where staging of one build stands after a hub message.
+pub(super) enum StagingStatus {
+    InProgress,
+    /// Everything staged; start the build.
+    Ready,
+    /// Deferred paths never became valid; ask the hub for them.
+    NeedResend(Vec<String>),
+}
 
 /// The worker must not trust the hub for filesystem-relevant strings:
 /// build ids become path components, output paths are packed (and on
@@ -85,6 +98,14 @@ pub(super) struct ActiveBuild {
     /// Paths reported missing, waiting for PathInfo + NAR. The value
     /// holds the parsed metadata once it arrived.
     pending: HashMap<String, Option<ValidPathInfo>>,
+    /// Missing paths another build is importing; not requested from
+    /// the hub, re-checked when staging completes.
+    deferred: Vec<String>,
+    /// Paths this build claimed in `WorkerCtx::staging_inflight`.
+    registered: HashSet<String>,
+    /// True once the tmp dir archive finished unpacking.
+    tmp_dir_done: bool,
+    resend_rounds: u8,
     /// Daemon connection; carries this build's temp roots, so it must
     /// outlive the build. None while an Importer borrows it.
     daemon: Option<DaemonConn>,
@@ -133,6 +154,10 @@ impl ActiveBuild {
             permit: None,
             inputs: Vec::new(),
             pending: HashMap::new(),
+            deferred: Vec::new(),
+            registered: HashSet::new(),
+            tmp_dir_done: false,
+            resend_rounds: 0,
             daemon: None,
             importer: None,
             tmp_unpacker: None,
@@ -170,16 +195,43 @@ impl ActiveBuild {
             .await
             .context("querying valid paths")?;
         let mut missing = Vec::new();
+        // One check-and-insert under the lock, so of several builds
+        // negotiating the same missing path exactly one requests it.
+        let mut inflight = self.ctx.staging_inflight.lock().unwrap();
         for (p, sp) in parsed {
             if valid.contains(&sp) {
                 self.inputs.push(p.clone());
+            } else if inflight.contains(p) {
+                // Another build is importing it; re-checked in
+                // complete_staging.
+                self.deferred.push(p.clone());
             } else {
+                inflight.insert(p.clone());
+                self.registered.insert(p.clone());
                 self.pending.insert(p.clone(), None);
                 missing.push(p.clone());
             }
         }
         self.daemon = Some(daemon);
         Ok(missing)
+    }
+
+    /// Drop a path's claim in the in-flight registry so other builds
+    /// stop deferring to it.
+    fn deregister(&mut self, path: &str) {
+        if self.registered.remove(path) {
+            self.ctx.staging_inflight.lock().unwrap().remove(path);
+        }
+    }
+
+    fn deregister_all(&mut self) {
+        if self.registered.is_empty() {
+            return;
+        }
+        let mut inflight = self.ctx.staging_inflight.lock().unwrap();
+        for p in self.registered.drain() {
+            inflight.remove(&p);
+        }
     }
 
     pub(super) fn feed_path_info(&mut self, pi: &PathInfoMsg) -> Result<()> {
@@ -245,14 +297,17 @@ impl ActiveBuild {
             if send_failed {
                 bail!("input import ended early for {}", n.store_path);
             }
+            self.deregister(&n.store_path);
             self.inputs.push(n.store_path);
         }
         Ok(())
     }
 
-    /// Returns true when the tmp dir transfer completed, which is the
-    /// signal to start the build.
-    pub(super) async fn feed_tmp_dir(&mut self, t: crate::proto::TmpDirArchive) -> Result<bool> {
+    /// Reports staging progress; the tmp dir eof completes round one.
+    pub(super) async fn feed_tmp_dir(
+        &mut self,
+        t: crate::proto::TmpDirArchive,
+    ) -> Result<StagingStatus> {
         let (tx, _) = self.tmp_unpacker.get_or_insert_with(|| {
             let dest = self.dir.join("top");
             let (tx, rx) = mpsc::channel::<Vec<u8>>(8);
@@ -275,31 +330,32 @@ impl ActiveBuild {
             let (tx, task) = self.tmp_unpacker.take().unwrap();
             drop(tx);
             task.await??;
-            if self.importer.is_some() {
-                bail!("tmp dir transfer finished during an input NAR transfer");
-            }
-            self.finish_staging().await?;
-            return Ok(true);
+            self.tmp_dir_done = true;
+            return self.complete_staging().await;
         }
-        Ok(false)
+        Ok(StagingStatus::InProgress)
     }
 
-    /// Inputs the hub skipped (streamed for an earlier build in this
-    /// session) never got a NAR here; verify they are valid in the
-    /// local store before treating them as bind-mount sources.
-    async fn finish_staging(&mut self) -> Result<()> {
-        if self.pending.is_empty() {
-            return Ok(());
+    /// End of a staging round (tmp dir eof or StagingComplete): every
+    /// requested NAR must have arrived; deferred paths that are still
+    /// invalid are re-requested instead of failing the build.
+    pub(super) async fn complete_staging(&mut self) -> Result<StagingStatus> {
+        if !self.tmp_dir_done {
+            bail!("hub signalled staging completion before the tmp dir arrived");
+        }
+        if self.importer.is_some() {
+            bail!("staging round ended during an input NAR transfer");
+        }
+        if let Some(p) = self.pending.keys().next() {
+            bail!("hub never sent a NAR for requested input {p}");
+        }
+        if self.deferred.is_empty() {
+            return Ok(StagingStatus::Ready);
         }
         let store_dir = StoreDir::default();
         let mut set = StorePathSet::new();
-        let mut skipped = Vec::new();
-        for (p, info) in std::mem::take(&mut self.pending) {
-            if info.is_some() {
-                bail!("hub sent path info but no NAR for {p}");
-            }
-            set.insert(store_dir.parse(&p)?);
-            skipped.push(p);
+        for p in &self.deferred {
+            set.insert(store_dir.parse(p)?);
         }
         let daemon = self
             .daemon
@@ -308,16 +364,34 @@ impl ActiveBuild {
         let valid = daemon
             .query_valid_paths(&set, false)
             .await
-            .context("re-checking inputs staged for earlier builds")?;
-        for p in skipped {
-            if !valid.contains(&store_dir.parse(&p)?) {
-                bail!(
-                    "input {p} was staged for an earlier build but is not valid in the local store"
-                );
+            .context("re-checking inputs another build was importing")?;
+        let mut still_missing = Vec::new();
+        for p in std::mem::take(&mut self.deferred) {
+            if valid.contains(&store_dir.parse(&p)?) {
+                self.inputs.push(p);
+            } else {
+                still_missing.push(p);
             }
-            self.inputs.push(p);
         }
-        Ok(())
+        if still_missing.is_empty() {
+            return Ok(StagingStatus::Ready);
+        }
+        if self.resend_rounds >= MAX_RESEND_ROUNDS {
+            bail!(
+                "input {} was expected from another build's import but never became valid",
+                still_missing[0]
+            );
+        }
+        self.resend_rounds += 1;
+        // This build imports them itself now: claim and expect them.
+        let mut inflight = self.ctx.staging_inflight.lock().unwrap();
+        for p in &still_missing {
+            if inflight.insert(p.clone()) {
+                self.registered.insert(p.clone());
+            }
+            self.pending.insert(p.clone(), None);
+        }
+        Ok(StagingStatus::NeedResend(still_missing))
     }
 
     /// Tear down a build abandoned before execution: stop the import
@@ -325,6 +399,7 @@ impl ActiveBuild {
     /// daemon connection (and with it the temp roots) drops here; a
     /// half-imported path is the daemon's to clean up.
     pub(super) async fn abort(mut self) {
+        self.deregister_all();
         if let Some(Importer { tx, task, .. }) = self.importer.take() {
             drop(tx);
             task.abort();


### PR DESCRIPTION
The hub skipped re-streaming inputs it believed a worker already got this session. That belief could go stale (failed import, GC, races) and the worker then failed the build:

  input ... was staged for an earlier build but is not valid in the
  local store

Move dedup to the worker: it defers paths another of its builds is already importing, and the hub streams exactly what MissingPaths asks for. If a deferred path is still invalid when staging ends, the worker re-requests it with a second MissingPaths; the hub streams it and ends the round with a new StagingComplete message. Rounds are capped on both sides. The common path (tmp dir eof starts the build) and mixed hub/worker versions are unchanged.