### PR TITLE
worker: drop the idmapped pack mount leftovers

### DIFF
--- a/crates/tribuchet/src/worker.rs
+++ b/crates/tribuchet/src/worker.rs
@@ -269,7 +269,7 @@ async fn run_async(opts: WorkerConfig) -> Result<()> {
     let builds_dir = opts.state_dir.join("builds");
     fs::create_dir_all(&builds_dir)?;
     // Traverse-only so leased build uids reach their own tree but
-    // other local users get no listing; see BuildOwner.
+    // other local users get no listing.
     fs::set_permissions(&builds_dir, fs::Permissions::from_mode(0o711))?;
     sweep_state_dir(&opts.state_dir);
     // Arc: SecretKey is not Clone (zeroized on drop); build threads share it.

--- a/crates/tribuchet/src/worker/agent/linux.rs
+++ b/crates/tribuchet/src/worker/agent/linux.rs
@@ -126,7 +126,6 @@ pub(super) fn spawn_builder(
     let (_ns_fd, ns_path) = userns::inherited_ns(&userns.fd)?;
     spec.leased_userns = Some(ns_path);
     spec.leased_uid_count.get_or_insert(UID_COUNT);
-    spec.pool_base = Some(userns.uid_base);
     spec.cgroup = confinement
         .cgroup_base
         .as_deref()

--- a/crates/tribuchet/src/worker/sandbox.rs
+++ b/crates/tribuchet/src/worker/sandbox.rs
@@ -75,10 +75,6 @@ pub struct SandboxSpec {
     /// Uids mapped in that namespace at in-ns 0 (1 or 65536).
     #[serde(default)]
     pub leased_uid_count: Option<u32>,
-    /// First host uid of the leased block, for the idmapped pack
-    /// mount that reads permission-restricted outputs.
-    #[serde(default)]
-    pub pool_base: Option<u32>,
     /// Fixed-output build: private netns with the presto-pasta
     /// user-mode NAT; host abstract sockets and loopback services
     /// stay unreachable.
@@ -174,7 +170,6 @@ pub fn prepare(
         leased_userns: opts.leased_userns.clone(),
         leased_uid_count: opts.leased_uid_count,
         // filled in by the agent, like the namespace and cgroup
-        pool_base: None,
         net_isolation: opts.net_isolation && a.fixed_output,
         net_policy: opts.net_policy.clone(),
         emulator: opts.emulator.map(Path::to_path_buf),

--- a/crates/tribuchet/tests/e2e.rs
+++ b/crates/tribuchet/tests/e2e.rs
@@ -350,7 +350,7 @@ in derivation {{
 #[test]
 fn build_restricted_permissions() {
     // The builder tightens its output to owner-only permissions, so
-    // packing needs the idmapped mount to read it.
+    // packing needs the agent's make-readable pass.
     let out = succeed(
         Node::Hub,
         "nix-build /etc/tt/restrictedperms.nix --no-out-link",

--- a/nix/tests/restrictedperms.nix
+++ b/nix/tests/restrictedperms.nix
@@ -1,7 +1,7 @@
-# The builder restricts its output to owner-only permissions (like
-# python's dist outputs). The worker packs as an unprivileged uid
+# The builder restricts its output to owner-only permissions, like
+# python's dist outputs. The worker packs as an unprivileged uid
 # while the files belong to the leased build uid, so reading them
-# takes the idmapped pack mount.
+# takes the agent's make-readable pass.
 {
   bash,
   coreutils,


### PR DESCRIPTION
The agent path reads restricted outputs via its make-readable pass
inside the userns, so SandboxSpec.pool_base is written but never
read. Remove it and fix the comments that still mention the idmapped
mount and the removed BuildOwner.
