### PR TITLE
Container route follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ $ podman run -d --name tribuchet-worker \
     tribuchet-worker:latest
 ```
 
+The extra syscall rule the sandbox needs is also available on its own
+in [`nix/seccomp-additions.json`](nix/seccomp-additions.json), to
+append to a base profile of your choice.
+
 For docker replace `unmask=ALL` with `systempaths=unconfined`. On
 Kubernetes ship the profile as a `Localhost` seccomp profile, or fall
 back to `Unconfined`, and set `procMount: Unmasked`.

--- a/crates/tribuchet/src/config.rs
+++ b/crates/tribuchet/src/config.rs
@@ -182,7 +182,7 @@ pub struct WorkerConfig {
     pub spawn_agents: u32,
     /// First uid used by spawned agents. Agent i runs as uid base+i-1
     /// and maps the 65536-uid block starting at base+i*65536. Needs a
-    /// root worker. Unset, builds share the worker uid.
+    /// root worker. If unset, builds share the worker uid.
     #[serde(default)]
     pub agent_uid_base: Option<u32>,
 }

--- a/crates/tribuchet/src/worker.rs
+++ b/crates/tribuchet/src/worker.rs
@@ -480,7 +480,7 @@ async fn session_loop(
                 let occupied = max_jobs as usize - ctx.slots.available_permits();
                 let running = occupied.saturating_sub(pending.len() + active.len());
                 out_tx.send(msg(worker_message::Msg::Heartbeat(Heartbeat {
-                    running_jobs: running as u32,
+                    running_jobs: u32::try_from(running).unwrap_or(u32::MAX),
                     load1: loadavg1(),
                 }))).await?;
                 continue;
@@ -492,39 +492,7 @@ async fn session_loop(
         let Some(m) = m.msg else { continue };
         match m {
             hub_message::Msg::Assignment(a) => {
-                // A key we already hold means a hub (likely freshly
-                // restarted) re-dispatched a build we are running or
-                // have finished: adopt the new build_id and deliver
-                // the result when there is one, instead of building
-                // again.
-                if ctx.adopt_assignment(&a, out_tx) {
-                    tracing::info!(id = a.build_id, key = a.dedupe_key, "build resumed");
-                    out_tx
-                        .send(msg(worker_message::Msg::Resumed(Resumed {
-                            build_id: a.build_id.clone(),
-                        })))
-                        .await?;
-                    let ctx = ctx.clone();
-                    tokio::task::spawn_blocking(move || try_deliver(&ctx, &a.dedupe_key));
-                    continue;
-                }
-                // Resumed assignments are credit-free on the hub, so
-                // never funded a permit into `pending`.
-                let permit = pending.pop();
-                tracing::info!(id = a.build_id, "build assigned");
-                // build ids are never reused; a duplicate is a confused hub
-                if let Some(old) = active.remove(&a.build_id) {
-                    tracing::warn!(id = old.assignment.build_id, "discarding duplicate build");
-                    old.abort().await;
-                }
-                let build_id = a.build_id.clone();
-                match validate_assignment(&a).and_then(|()| ActiveBuild::new(a, ctx.clone())) {
-                    Ok(mut b) => {
-                        b.permit = permit;
-                        active.insert(build_id, b);
-                    }
-                    Err(e) => fail_build(out_tx, &build_id, &e).await?,
-                }
+                handle_assignment(a, active, &mut pending, out_tx, ctx).await?;
             }
             hub_message::Msg::PathOffer(offer) => {
                 let Some(build) = active.get_mut(&offer.build_id) else {
@@ -582,29 +550,7 @@ async fn session_loop(
                     abort_active(active, &id, out_tx, &e).await?;
                 }
             }
-            hub_message::Msg::Cancel(c) => {
-                tracing::info!(id = c.build_id, "hub cancelled the build");
-                // Still staging: tear it down right here. Already
-                // executing: flag its dedupe key for the supervising
-                // loop. The key is the stable identity; the build_id
-                // the hub knows may predate a concurrent resume.
-                if let Some(build) = active.remove(&c.build_id) {
-                    build.abort().await;
-                    fail_build(out_tx, &c.build_id, &anyhow::anyhow!("build cancelled")).await?;
-                } else {
-                    // Only flag builds that are still running: a key
-                    // flagged for an already-finished build would
-                    // never be consumed and would kill the next build
-                    // sharing that dedupe key. The flag is set while
-                    // holding the registry lock so a build finishing
-                    // concurrently (record_finished) cannot slip
-                    // between the check and the insert.
-                    let map = ctx.resumable.lock().unwrap();
-                    if map.get(&c.dedupe_key).is_some_and(|e| e.finished.is_none()) {
-                        ctx.cancelled.lock().unwrap().insert(c.dedupe_key);
-                    }
-                }
-            }
+            hub_message::Msg::Cancel(c) => handle_cancel(c, active, out_tx, ctx).await?,
             hub_message::Msg::ResultAck(a) => {
                 ack_delivery(ctx, &a.dedupe_key, &a.build_id);
             }
@@ -642,6 +588,77 @@ async fn advance_staging(
                 })))
                 .await?;
         }
+    }
+    Ok(())
+}
+/// Cancel a build. Still staging: tear it down right here. Already
+/// executing: flag its dedupe key for the supervising loop. The key
+/// is the stable identity, the build_id the hub knows may predate a
+/// concurrent resume.
+async fn handle_cancel(
+    c: crate::proto::CancelBuild,
+    active: &mut HashMap<String, ActiveBuild>,
+    out_tx: &mpsc::Sender<WorkerMessage>,
+    ctx: &Arc<WorkerCtx>,
+) -> Result<()> {
+    tracing::info!(id = c.build_id, "hub cancelled the build");
+    if let Some(build) = active.remove(&c.build_id) {
+        build.abort().await;
+        fail_build(out_tx, &c.build_id, &anyhow::anyhow!("build cancelled")).await?;
+    } else {
+        // Only flag builds that are still running: a key flagged for
+        // an already-finished build would never be consumed and would
+        // kill the next build sharing that dedupe key. The flag is
+        // set while holding the registry lock so a build finishing
+        // concurrently in record_finished cannot slip between the
+        // check and the insert.
+        let map = ctx.resumable.lock().unwrap();
+        if map.get(&c.dedupe_key).is_some_and(|e| e.finished.is_none()) {
+            ctx.cancelled.lock().unwrap().insert(c.dedupe_key);
+        }
+    }
+    Ok(())
+}
+
+/// Adopt a re-dispatched build or stage a fresh assignment.
+async fn handle_assignment(
+    a: BuildAssignment,
+    active: &mut HashMap<String, ActiveBuild>,
+    pending: &mut Vec<tokio::sync::OwnedSemaphorePermit>,
+    out_tx: &mpsc::Sender<WorkerMessage>,
+    ctx: &Arc<WorkerCtx>,
+) -> Result<()> {
+    // A key we already hold means a hub (likely freshly restarted)
+    // re-dispatched a build we are running or have finished: adopt
+    // the new build_id and deliver the result when there is one,
+    // instead of building again.
+    if ctx.adopt_assignment(&a, out_tx) {
+        tracing::info!(id = a.build_id, key = a.dedupe_key, "build resumed");
+        out_tx
+            .send(msg(worker_message::Msg::Resumed(Resumed {
+                build_id: a.build_id.clone(),
+            })))
+            .await?;
+        let ctx = ctx.clone();
+        tokio::task::spawn_blocking(move || try_deliver(&ctx, &a.dedupe_key));
+        return Ok(());
+    }
+    // Resumed assignments are credit-free on the hub, so never funded
+    // a permit into `pending`.
+    let permit = pending.pop();
+    tracing::info!(id = a.build_id, "build assigned");
+    // build ids are never reused; a duplicate is a confused hub
+    if let Some(old) = active.remove(&a.build_id) {
+        tracing::warn!(id = old.assignment.build_id, "discarding duplicate build");
+        old.abort().await;
+    }
+    let build_id = a.build_id.clone();
+    match validate_assignment(&a).and_then(|()| ActiveBuild::new(a, ctx.clone())) {
+        Ok(mut b) => {
+            b.permit = permit;
+            active.insert(build_id, b);
+        }
+        Err(e) => fail_build(out_tx, &build_id, &e).await?,
     }
     Ok(())
 }

--- a/crates/tribuchet/src/worker/agent_spawn.rs
+++ b/crates/tribuchet/src/worker/agent_spawn.rs
@@ -11,9 +11,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, ensure};
 
-/// Uids per agent: the agent's own uid, then its 65536-uid block.
-/// Agent i gets uid `base + i - 1` and block `base + i * 65536`, so
-/// builds never share the agent's uid.
+/// Size of each agent's mapped uid block.
 const UID_BLOCK: u32 = 65536;
 
 /// One spawned agent slot.

--- a/crates/tribuchet/src/worker/build.rs
+++ b/crates/tribuchet/src/worker/build.rs
@@ -545,7 +545,7 @@ async fn pack_extras(
         .map(String::as_str)
         .chain(spec_outputs.iter().map(String::as_str))
         .collect();
-    let mut queue: Vec<String> = outputs
+    let queue: Vec<String> = outputs
         .iter()
         .flat_map(|o| o.references.iter())
         .filter(|r| !known.contains(r.as_str()))
@@ -555,41 +555,7 @@ async fn pack_extras(
         return Ok(Vec::new());
     }
     let store_dir = StoreDir::default();
-    let mut daemon = DaemonClient::builder()
-        .connect_daemon()
-        .await
-        .context("connecting to the local nix-daemon")?;
-    // Transitive closure: the hub daemon rejects an import whose
-    // references are not already valid.
-    let mut infos: HashMap<String, UnkeyedValidPathInfo> = HashMap::new();
-    while let Some(path) = queue.pop() {
-        if infos.contains_key(&path) {
-            continue;
-        }
-        let sp = StorePath::from_base_path(store_base(&path))
-            .with_context(|| format!("parsing extra path {path}"))?;
-        // Hold a temp root so the daemon does not GC the path while
-        // we read it.
-        daemon
-            .add_temp_root(&sp)
-            .await
-            .with_context(|| format!("temp-rooting {path}"))?;
-        let info = daemon
-            .query_path_info(&sp)
-            .await
-            .with_context(|| format!("queryPathInfo {path}"))?
-            .ok_or_else(|| anyhow::anyhow!("extra {path} vanished from store"))?;
-        for r in &info.references {
-            let r = r
-                .to_absolute_path(&store_dir)
-                .to_string_lossy()
-                .into_owned();
-            if !known.contains(r.as_str()) {
-                queue.push(r);
-            }
-        }
-        infos.insert(path, info);
-    }
+    let mut infos = extra_closure(queue, &known, &store_dir).await?;
     // Referenced-before-referrer, matching hub-side sequential import.
     let ordered = topo_order(infos.keys().cloned(), |p| {
         infos[p]
@@ -656,6 +622,45 @@ async fn pack_extras(
         });
     }
     Ok(out)
+}
+
+/// Walk `queue` into a transitive closure of path infos, temp-rooting
+/// each path so the daemon does not GC it while we read it. The hub
+/// daemon rejects an import whose references are not already valid.
+async fn extra_closure(
+    mut queue: Vec<String>,
+    known: &BTreeSet<&str>,
+    store_dir: &StoreDir,
+) -> Result<HashMap<String, UnkeyedValidPathInfo>> {
+    let mut daemon = DaemonClient::builder()
+        .connect_daemon()
+        .await
+        .context("connecting to the local nix-daemon")?;
+    let mut infos: HashMap<String, UnkeyedValidPathInfo> = HashMap::new();
+    while let Some(path) = queue.pop() {
+        if infos.contains_key(&path) {
+            continue;
+        }
+        let sp = StorePath::from_base_path(store_base(&path))
+            .with_context(|| format!("parsing extra path {path}"))?;
+        daemon
+            .add_temp_root(&sp)
+            .await
+            .with_context(|| format!("temp-rooting {path}"))?;
+        let info = daemon
+            .query_path_info(&sp)
+            .await
+            .with_context(|| format!("queryPathInfo {path}"))?
+            .ok_or_else(|| anyhow::anyhow!("extra {path} vanished from store"))?;
+        for r in &info.references {
+            let r = r.to_absolute_path(store_dir).to_string_lossy().into_owned();
+            if !known.contains(r.as_str()) {
+                queue.push(r);
+            }
+        }
+        infos.insert(path, info);
+    }
+    Ok(infos)
 }
 
 struct NarPackResult {

--- a/crates/tribuchet/src/worker/sandbox/linux.rs
+++ b/crates/tribuchet/src/worker/sandbox/linux.rs
@@ -870,7 +870,7 @@ fn apply_process_limits(system: &str) -> io::Result<()> {
     ) {
         0x0008 // PER_LINUX32
     } else {
-        unsafe { libc::personality(0xFFFF_FFFF) as libc::c_ulong }
+        libc::c_ulong::from(unsafe { libc::personality(0xFFFF_FFFF) }.cast_unsigned())
     };
     unsafe {
         libc::personality(base | 0x0004_0000 /* ADDR_NO_RANDOMIZE */)

--- a/nix/seccomp-additions.json
+++ b/nix/seccomp-additions.json
@@ -1,0 +1,22 @@
+{
+  "names": [
+    "clone",
+    "clone3",
+    "fsconfig",
+    "fsmount",
+    "fsopen",
+    "fspick",
+    "mount",
+    "mount_setattr",
+    "move_mount",
+    "open_tree",
+    "pivot_root",
+    "setdomainname",
+    "sethostname",
+    "setns",
+    "umount",
+    "umount2",
+    "unshare"
+  ],
+  "action": "SCMP_ACT_ALLOW"
+}

--- a/nix/seccomp-profile.nix
+++ b/nix/seccomp-profile.nix
@@ -1,33 +1,17 @@
-# Podman's default profile plus the namespace and mount syscalls the
-# build sandbox needs. They are stripped from the existing rules first
-# because the default carries explicit EPERM rules for some of them.
+# Podman's default profile plus the sandbox rule from
+# seccomp-additions.json. The syscalls are stripped from the existing
+# rules first because the default carries explicit EPERM rules for
+# some of them.
 {
   runCommand,
   jq,
   podman,
 }:
 runCommand "tribuchet-seccomp.json" { nativeBuildInputs = [ jq ]; } ''
-  jq '[
-    "clone",
-    "clone3",
-    "fsconfig",
-    "fsmount",
-    "fsopen",
-    "fspick",
-    "mount",
-    "mount_setattr",
-    "move_mount",
-    "open_tree",
-    "pivot_root",
-    "setdomainname",
-    "sethostname",
-    "setns",
-    "umount",
-    "umount2",
-    "unshare"
-  ] as $sandbox
-  | .syscalls |= [
-      (.[] | .names -= $sandbox | select(.names != [])),
-      { names: $sandbox, action: "SCMP_ACT_ALLOW" }
-    ]' ${podman.src}/vendor/go.podman.io/common/pkg/seccomp/seccomp.json > $out
+  jq --slurpfile add ${./seccomp-additions.json} '
+    $add[0].names as $sandbox
+    | .syscalls |= [
+        (.[] | .names -= $sandbox | select(.names != [])),
+        $add[0]
+      ]' ${podman.src}/vendor/go.podman.io/common/pkg/seccomp/seccomp.json > $out
 ''


### PR DESCRIPTION
Splits the seccomp additions into nix/seccomp-additions.json for reuse, tightens two agent spawn comments, and clears the clippy baseline by splitting session_loop and pack_extras and fixing the two lossy casts.