### PR TITLE
sandbox-proto: replace the JSON envelope with protobuf messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,8 +1849,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "nix",
- "serde",
- "serde_json",
+ "prost",
+ "prost-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ tokio-stream = "0.1"
 tonic = { version = "0.14", features = ["tls-ring"] }
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
+prost-build = "0.14"
 tower = "0.5"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/sandbox-proto/Cargo.toml
+++ b/crates/sandbox-proto/Cargo.toml
@@ -7,8 +7,10 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 nix.workspace = true
-serde.workspace = true
-serde_json.workspace = true
+prost.workspace = true
+
+[build-dependencies]
+prost-build.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sandbox-proto/build.rs
+++ b/crates/sandbox-proto/build.rs
@@ -1,0 +1,9 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=proto/agent.proto");
+    prost_build::Config::new()
+        // StartRequest dwarfs the other Call variants (clippy
+        // large_enum_variant).
+        .boxed(".agent.Call.call.start")
+        .compile_protos(&["proto/agent.proto"], &["proto"])?;
+    Ok(())
+}

--- a/crates/sandbox-proto/proto/agent.proto
+++ b/crates/sandbox-proto/proto/agent.proto
@@ -1,0 +1,103 @@
+// Messages spoken with the per-uid build agents. One daemon per pool
+// user; a connection whose Start is accepted holds the lease. The
+// agent runs one build at a time and survives worker restarts.
+// Control calls (Kill, Adopt, Finish, Cleanup) are accepted on any
+// connection; only a second Start is refused with ERROR_BUSY.
+syntax = "proto3";
+package agent;
+
+// One request from the worker; the agent answers with a Reply.
+message Call {
+  oneof call {
+    StartRequest start = 1;
+    AdoptRequest adopt = 2;
+    StatusRequest status = 3;
+    KillRequest kill = 4;
+    FinishRequest finish = 5;
+    CleanupRequest cleanup = 6;
+  }
+}
+
+// Kill, Finish and Cleanup answer with `empty`; ExitNotice arrives
+// later on the Start/Adopt connection.
+message Reply {
+  oneof reply {
+    string error = 1;
+    StartReply start = 2;
+    AdoptReply adopt = 3;
+    StatusReply status = 4;
+    ExitNotice exit = 5;
+    Empty empty = 6;
+  }
+}
+
+message Empty {}
+
+// Run one build. Attached fd 0 is the zstd tar of the build's tmp dir;
+// the agent unpacks it into its scratch dir, rewrites env values
+// referencing `tmp_dir_in_sandbox`, confines and execs the builder.
+message StartRequest {
+  string build_id = 1;
+  string builder = 2;
+  repeated string args = 3;
+  map<string, string> env = 4;
+  // In-sandbox tmp dir path (e.g. "/build") env values may reference.
+  string tmp_dir_in_sandbox = 5;
+  // SBPL profile text, may reference SCRATCH_DIR_PARAM.
+  string profile = 6;
+  // Linux: the worker's sandbox spec as JSON; the agent fills in its
+  // scratch paths and user namespace and runs the setup stage with it.
+  optional string sandbox_json = 7;
+  // Scratch output store paths, acted on by Finish and Cleanup.
+  repeated string outputs = 8;
+  // memory.max for the build's cgroup. Unlimited when unset.
+  optional uint64 memory_max_bytes = 9;
+}
+
+// Attached fd 0 is a read handle on the build's log file.
+message StartReply {
+  int32 pid = 1;
+  // The agent-owned scratch dir the build runs in (its cwd).
+  string scratch_dir = 2;
+}
+
+// Sent on the Start/Adopt connection when the builder exits.
+message ExitNotice {
+  int32 exit_code = 1;
+}
+
+// Reattach to the build after a worker restart.
+message AdoptRequest {
+  string build_id = 1;
+}
+
+message AdoptReply {
+  int32 pid = 1;
+  string scratch_dir = 2;
+  // Set when the builder already exited.
+  optional int32 exit_code = 3;
+}
+
+// Which build the agent currently owns, so a fresh worker generation
+// can clean up builds a dead predecessor never recorded.
+message StatusRequest {}
+
+message StatusReply {
+  optional string current = 1;
+}
+
+// Kill the build's process group and every remaining process of the
+// agent's uid except the agent itself.
+message KillRequest {
+  string build_id = 1;
+}
+
+// Make the scratch output trees readable by the worker for packing.
+message FinishRequest {
+  string build_id = 1;
+}
+
+// Remove the scratch dir and outputs; the agent forgets the build.
+message CleanupRequest {
+  string build_id = 1;
+}

--- a/crates/sandbox-proto/src/agent.rs
+++ b/crates/sandbox-proto/src/agent.rs
@@ -1,15 +1,6 @@
-//! Messages spoken with the per-uid build agents.
-//!
-//! One daemon per pool user. The agents are the uid pool: a
-//! connection whose `Start` is accepted holds the lease. The agent
-//! runs one build at a time, keeps its scratch dir, log and exit
-//! status, and survives worker restarts. Control calls
-//! (`Kill`, `Adopt`, `Finish`, `Cleanup`) are accepted on any
-//! connection. Only a second `Start` is refused with [`ERROR_BUSY`].
+//! Generated agent messages; see proto/agent.proto for the protocol.
 
-use std::collections::HashMap;
-
-use serde::{Deserialize, Serialize};
+include!(concat!(env!("OUT_DIR"), "/agent.rs"));
 
 /// Directory of per-agent sockets (`<n>.sock`), root-owned and only
 /// group-reachable by the worker.
@@ -20,106 +11,7 @@ pub const SOCKET_DIR: &str = "/var/run/tribuchet/agents";
 /// fills it in via `sandbox_init_with_parameters`.
 pub const SCRATCH_DIR_PARAM: &str = "SCRATCH_DIR";
 
-pub const METHOD_START: &str = "com.tribuchet.Agent.Start";
-pub const METHOD_ADOPT: &str = "com.tribuchet.Agent.Adopt";
-pub const METHOD_STATUS: &str = "com.tribuchet.Agent.Status";
-pub const METHOD_KILL: &str = "com.tribuchet.Agent.Kill";
-pub const METHOD_FINISH: &str = "com.tribuchet.Agent.Finish";
-pub const METHOD_CLEANUP: &str = "com.tribuchet.Agent.Cleanup";
-
 /// The agent already runs a build, so the worker tries the next agent.
 pub const ERROR_BUSY: &str = "com.tribuchet.Agent.Busy";
 /// A control call named a build this agent does not hold.
 pub const ERROR_UNKNOWN_BUILD: &str = "com.tribuchet.Agent.UnknownBuild";
-
-/// Run one build. Attached fd 0 is the zstd tar of the build's tmp dir
-/// (structured attrs, passAsFile files). The agent unpacks it into its
-/// scratch dir, rewrites env values referencing `tmp_dir_in_sandbox`
-/// to that dir, applies the seatbelt profile in the forked child and
-/// execs the builder. Reply: [`StartReply`], then an [`ExitNotice`] on
-/// the same connection when the builder exits.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct StartRequest {
-    pub build_id: String,
-    pub builder: String,
-    pub args: Vec<String>,
-    pub env: HashMap<String, String>,
-    /// The hub's in-sandbox tmp dir path (e.g. "/build") that env
-    /// values may reference, rewritten to the agent's scratch dir.
-    pub tmp_dir_in_sandbox: String,
-    /// SBPL profile text, may reference [`SCRATCH_DIR_PARAM`].
-    pub profile: String,
-    /// Linux: the worker's serialized sandbox spec (bind mounts,
-    /// network policy, namespaces). The agent fills in its scratch
-    /// paths and pre-mapped user namespace and spawns the setup stage
-    /// with it instead of executing the builder directly.
-    #[serde(default)]
-    pub sandbox: Option<serde_json::Value>,
-    /// Scratch output store paths, acted on by `Finish` and `Cleanup`.
-    pub outputs: Vec<String>,
-    /// memory.max for the build's cgroup. Unlimited when unset.
-    #[serde(default)]
-    pub memory_max_bytes: Option<u64>,
-}
-
-/// Attached fd 0 is a read handle on the build's log file, so the
-/// worker tails it without filesystem access to the agent-owned
-/// scratch dir.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct StartReply {
-    pub pid: i32,
-    /// The agent-owned scratch dir the build runs in (its cwd).
-    pub scratch_dir: String,
-}
-
-/// Sent on the `Start`/`Adopt` connection when the builder exits.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ExitNotice {
-    pub exit_code: i32,
-}
-
-/// Reattach to the build after a worker restart. Reply: [`AdoptReply`]
-/// (log fd attached), then an [`ExitNotice`] if still running.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct AdoptRequest {
-    pub build_id: String,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct AdoptReply {
-    pub pid: i32,
-    pub scratch_dir: String,
-    /// Set when the builder already exited.
-    pub exit_code: Option<i32>,
-}
-
-/// Which build the agent currently owns, so a fresh worker generation
-/// can clean up builds a dead predecessor never recorded.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct StatusRequest {}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct StatusReply {
-    pub current: Option<String>,
-}
-
-/// Kill the build's process group, then every remaining process of the
-/// agent's uid except the agent itself (setsid escapes). Reply is `{}`.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct KillRequest {
-    pub build_id: String,
-}
-
-/// After a successful exit: make the scratch output trees readable by
-/// the worker so it can pack them. Reply is `{}`.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct FinishRequest {
-    pub build_id: String,
-}
-
-/// Remove the scratch dir and the scratch store outputs. The agent
-/// forgets the build and exits when idle. Reply is `{}`.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct CleanupRequest {
-    pub build_id: String,
-}

--- a/crates/sandbox-proto/src/framing.rs
+++ b/crates/sandbox-proto/src/framing.rs
@@ -1,6 +1,7 @@
-//! Length-prefixed JSON messages (u32 little-endian, then the object)
-//! over a unix stream socket, with file descriptors attached via
-//! SCM_RIGHTS. gRPC cannot carry fds, hence the separate protocol.
+//! Length-prefixed protobuf messages (u32 little-endian, then the
+//! encoded [`agent::Call`]/[`agent::Reply`]) over a unix stream
+//! socket, with file descriptors attached via SCM_RIGHTS. gRPC cannot
+//! carry fds, hence the separate protocol.
 
 use std::io::{IoSlice, IoSliceMut, Read, Write};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
@@ -8,16 +9,16 @@ use std::os::unix::net::UnixStream;
 
 use anyhow::{Context, Result, bail, ensure};
 use nix::sys::socket::{ControlMessage, ControlMessageOwned, MsgFlags, recvmsg, sendmsg};
-use serde::{Deserialize, Serialize};
+use prost::Message;
+
+use crate::agent::{self, call, reply};
 
 /// Peers are worker and agent on the same host; anything bigger than
 /// this is a corrupted length prefix, not a real message.
 const MAX_MESSAGE: usize = 64 * 1024 * 1024;
 
-/// Send one message: `{"method": ..., "parameters": ...}` for calls,
-/// `{"parameters": ...}` for replies, `{"error": ...}` for errors.
-fn send_message(sock: &UnixStream, message: &serde_json::Value, fds: &[RawFd]) -> Result<()> {
-    let body = serde_json::to_vec(message)?;
+fn send_message(sock: &UnixStream, body: &impl Message, fds: &[RawFd]) -> Result<()> {
+    let body = body.encode_to_vec();
     let mut buf = (u32::try_from(body.len())?).to_le_bytes().to_vec();
     buf.extend_from_slice(&body);
     let iov = [IoSlice::new(&buf)];
@@ -33,7 +34,7 @@ fn send_message(sock: &UnixStream, message: &serde_json::Value, fds: &[RawFd]) -
 /// Receive one message and any attached fds. Only the length prefix
 /// and the message body are read, so the peer's next message stays
 /// queued.
-fn recv_message(sock: &UnixStream) -> Result<(serde_json::Value, Vec<OwnedFd>)> {
+fn recv_message<M: Message + Default>(sock: &UnixStream) -> Result<(M, Vec<OwnedFd>)> {
     let mut len_buf = [0u8; 4];
     let mut cmsg_buf = nix::cmsg_space!([RawFd; 8]);
     // The first read also collects the attached fds.
@@ -70,33 +71,24 @@ fn recv_message(sock: &UnixStream) -> Result<(serde_json::Value, Vec<OwnedFd>)> 
     (&mut &*sock)
         .read_exact(&mut data)
         .context("receiving message")?;
-    let value = serde_json::from_slice(&data).context("parsing message")?;
+    let value = M::decode(data.as_slice()).context("decoding message")?;
     Ok((value, fds))
 }
 
 /// Send a method call.
 ///
 /// # Errors
-/// Serialization or socket errors.
-pub fn send_call<T: Serialize>(
-    sock: &UnixStream,
-    method: &str,
-    parameters: &T,
-    fds: &[RawFd],
-) -> Result<()> {
-    send_message(
-        sock,
-        &serde_json::json!({ "method": method, "parameters": parameters }),
-        fds,
-    )
+/// Socket errors.
+pub fn send_call(sock: &UnixStream, call: call::Call, fds: &[RawFd]) -> Result<()> {
+    send_message(sock, &agent::Call { call: Some(call) }, fds)
 }
 
 /// Send a successful reply.
 ///
 /// # Errors
-/// Serialization or socket errors.
-pub fn send_reply<T: Serialize>(sock: &UnixStream, parameters: &T, fds: &[RawFd]) -> Result<()> {
-    send_message(sock, &serde_json::json!({ "parameters": parameters }), fds)
+/// Socket errors.
+pub fn send_reply(sock: &UnixStream, reply: reply::Reply, fds: &[RawFd]) -> Result<()> {
+    send_message(sock, &agent::Reply { reply: Some(reply) }, fds)
 }
 
 /// Send an error reply.
@@ -104,30 +96,16 @@ pub fn send_reply<T: Serialize>(sock: &UnixStream, parameters: &T, fds: &[RawFd]
 /// # Errors
 /// Socket errors.
 pub fn send_error(sock: &UnixStream, error: &str) -> Result<()> {
-    send_message(sock, &serde_json::json!({ "error": error }), &[])
+    send_reply(sock, reply::Reply::Error(error.to_owned()), &[])
 }
 
-/// Receive a method call and deserialize its parameters.
+/// Receive a method call.
 ///
 /// # Errors
 /// Socket errors, a closed connection, or a malformed call.
-pub fn recv_call<T: for<'de> Deserialize<'de>>(
-    sock: &UnixStream,
-) -> Result<(String, T, Vec<OwnedFd>)> {
-    let (value, fds) = recv_message(sock)?;
-    let method = value
-        .get("method")
-        .and_then(|m| m.as_str())
-        .context("call without method")?
-        .to_owned();
-    let parameters = serde_json::from_value(
-        value
-            .get("parameters")
-            .cloned()
-            .unwrap_or(serde_json::json!({})),
-    )
-    .context("parsing call parameters")?;
-    Ok((method, parameters, fds))
+pub fn recv_call(sock: &UnixStream) -> Result<(call::Call, Vec<OwnedFd>)> {
+    let (msg, fds): (agent::Call, _) = recv_message(sock)?;
+    Ok((msg.call.context("call without a payload")?, fds))
 }
 
 /// Receive a reply; an error reply becomes an `Err`.
@@ -135,25 +113,18 @@ pub fn recv_call<T: for<'de> Deserialize<'de>>(
 /// # Errors
 /// Socket errors, a closed connection, a malformed reply, or an error
 /// reply from the peer.
-pub fn recv_reply<T: for<'de> Deserialize<'de>>(sock: &UnixStream) -> Result<(T, Vec<OwnedFd>)> {
-    let (value, fds) = recv_message(sock)?;
-    if let Some(error) = value.get("error").and_then(|e| e.as_str()) {
-        bail!("peer error: {error}");
+pub fn recv_reply(sock: &UnixStream) -> Result<(reply::Reply, Vec<OwnedFd>)> {
+    let (msg, fds): (agent::Reply, _) = recv_message(sock)?;
+    match msg.reply.context("reply without a payload")? {
+        reply::Reply::Error(e) => bail!("peer error: {e}"),
+        r => Ok((r, fds)),
     }
-    let parameters = serde_json::from_value(
-        value
-            .get("parameters")
-            .cloned()
-            .unwrap_or(serde_json::json!({})),
-    )
-    .context("parsing reply parameters")?;
-    Ok((parameters, fds))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::{AdoptRequest, ERROR_BUSY, METHOD_ADOPT, StartReply};
+    use crate::agent::{AdoptRequest, ERROR_BUSY, StartReply};
 
     #[test]
     fn call_roundtrip_with_fds() {
@@ -162,11 +133,15 @@ mod tests {
         let request = AdoptRequest {
             build_id: "b1".into(),
         };
-        send_call(&a, METHOD_ADOPT, &request, &[devnull.as_raw_fd()]).unwrap();
+        send_call(
+            &a,
+            call::Call::Adopt(request.clone()),
+            &[devnull.as_raw_fd()],
+        )
+        .unwrap();
 
-        let (method, received, fds): (_, AdoptRequest, _) = recv_call(&b).unwrap();
-        assert_eq!(method, METHOD_ADOPT);
-        assert_eq!(received, request);
+        let (received, fds) = recv_call(&b).unwrap();
+        assert_eq!(received, call::Call::Adopt(request));
         assert_eq!(fds.len(), 1);
     }
 
@@ -182,22 +157,28 @@ mod tests {
         };
         let sender = {
             std::thread::spawn(move || {
-                send_call(&a, METHOD_ADOPT, &request, &[]).unwrap();
+                send_call(&a, call::Call::Adopt(request), &[]).unwrap();
                 send_reply(
                     &a,
-                    &StartReply {
+                    reply::Reply::Start(StartReply {
                         pid: 7,
                         scratch_dir: "/scratch/next".into(),
-                    },
+                    }),
                     &[],
                 )
                 .unwrap();
             })
         };
 
-        let (_, received, _): (_, AdoptRequest, _) = recv_call(&b).unwrap();
+        let (received, _) = recv_call(&b).unwrap();
+        let call::Call::Adopt(received) = received else {
+            panic!("unexpected call {received:?}");
+        };
         assert_eq!(received.build_id, build_id);
-        let (reply, _): (StartReply, _) = recv_reply(&b).unwrap();
+        let (reply, _) = recv_reply(&b).unwrap();
+        let reply::Reply::Start(reply) = reply else {
+            panic!("unexpected reply {reply:?}");
+        };
         assert_eq!(reply.scratch_dir, "/scratch/next");
         sender.join().unwrap();
     }
@@ -207,14 +188,17 @@ mod tests {
         let (a, b) = UnixStream::pair().unwrap();
         send_reply(
             &a,
-            &StartReply {
+            reply::Reply::Start(StartReply {
                 pid: 42,
                 scratch_dir: "/scratch/b1".into(),
-            },
+            }),
             &[],
         )
         .unwrap();
-        let (reply, fds): (StartReply, _) = recv_reply(&b).unwrap();
+        let (reply, fds) = recv_reply(&b).unwrap();
+        let reply::Reply::Start(reply) = reply else {
+            panic!("unexpected reply {reply:?}");
+        };
         assert_eq!(reply.pid, 42);
         assert!(fds.is_empty());
     }
@@ -223,7 +207,7 @@ mod tests {
     fn error_reply_is_err() {
         let (a, b) = UnixStream::pair().unwrap();
         send_error(&a, ERROR_BUSY).unwrap();
-        let err = recv_reply::<StartReply>(&b).unwrap_err();
+        let err = recv_reply(&b).unwrap_err();
         assert!(err.to_string().contains("Busy"), "{err}");
     }
 
@@ -231,6 +215,6 @@ mod tests {
     fn closed_connection_is_err() {
         let (a, b) = UnixStream::pair().unwrap();
         drop(a);
-        assert!(recv_reply::<StartReply>(&b).is_err());
+        assert!(recv_reply(&b).is_err());
     }
 }

--- a/crates/sandbox-proto/src/lib.rs
+++ b/crates/sandbox-proto/src/lib.rs
@@ -1,8 +1,6 @@
 //! Wire protocol between the tribuchet worker and the per-uid build
-//! agents.
-//!
-//! The message types are plain serde structs with no OS calls; only
-//! the daemon speaking them cares about the platform.
+//! agents: protobuf messages (proto/agent.proto) framed over a unix
+//! socket that also carries file descriptors.
 
 pub mod agent;
 pub mod framing;

--- a/crates/tribuchet/src/worker/agent.rs
+++ b/crates/tribuchet/src/worker/agent.rs
@@ -7,7 +7,7 @@
 //! (non-worker) uid. The builder is the agent's child, so builds
 //! survive worker restarts and the agent holds the log and exit
 //! status until the worker adopts them. The protocol lives in
-//! crates/sandbox-proto/src/agent.rs.
+//! crates/sandbox-proto/proto/agent.proto.
 
 use std::collections::HashMap;
 use std::fs;
@@ -18,11 +18,10 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result, bail, ensure};
+use anyhow::{Context, Result, ensure};
 use sandbox_proto::agent::{
-    AdoptReply, AdoptRequest, CleanupRequest, ERROR_BUSY, ERROR_UNKNOWN_BUILD, ExitNotice,
-    FinishRequest, KillRequest, METHOD_ADOPT, METHOD_CLEANUP, METHOD_FINISH, METHOD_KILL,
-    METHOD_START, METHOD_STATUS, StartReply, StartRequest, StatusReply,
+    AdoptReply, AdoptRequest, CleanupRequest, ERROR_BUSY, ERROR_UNKNOWN_BUILD, Empty, ExitNotice,
+    FinishRequest, KillRequest, StartReply, StartRequest, StatusReply, call, reply,
 };
 use sandbox_proto::framing;
 
@@ -166,18 +165,17 @@ fn handle(agent: &Arc<Agent>, conn: &UnixStream) -> Result<()> {
         "connection from uid {peer_uid}, only the worker uid {} may lease",
         agent.worker_uid
     );
-    let (method, params, fds): (_, serde_json::Value, _) = framing::recv_call(conn)?;
-    match method.as_str() {
-        METHOD_START => handle_start(agent, conn, serde_json::from_value(params)?, fds),
-        METHOD_ADOPT => handle_adopt(agent, conn, &serde_json::from_value(params)?),
-        METHOD_STATUS => {
+    let (call, fds) = framing::recv_call(conn)?;
+    match call {
+        call::Call::Start(req) => handle_start(agent, conn, *req, fds),
+        call::Call::Adopt(req) => handle_adopt(agent, conn, &req),
+        call::Call::Status(_) => {
             let current = agent.current.lock().unwrap().as_ref().map(|b| b.id.clone());
-            framing::send_reply(conn, &StatusReply { current }, &[])
+            framing::send_reply(conn, reply::Reply::Status(StatusReply { current }), &[])
         }
-        METHOD_KILL => handle_kill(agent, conn, &serde_json::from_value(params)?),
-        METHOD_FINISH => handle_finish(agent, conn, &serde_json::from_value(params)?),
-        METHOD_CLEANUP => handle_cleanup(agent, conn, &serde_json::from_value(params)?),
-        m => bail!("unknown method {m}"),
+        call::Call::Kill(req) => handle_kill(agent, conn, &req),
+        call::Call::Finish(req) => handle_finish(agent, conn, &req),
+        call::Call::Cleanup(req) => handle_cleanup(agent, conn, &req),
     }
 }
 
@@ -233,10 +231,10 @@ fn handle_start(
     tracing::info!(id = req.build_id, pid, "builder started");
     framing::send_reply(
         conn,
-        &StartReply {
+        reply::Reply::Start(StartReply {
             pid,
             scratch_dir: build_dir.to_string_lossy().into_owned(),
-        },
+        }),
         &[log.as_raw_fd()],
     )?;
     notify_exit(conn, &exit)
@@ -256,11 +254,11 @@ fn handle_adopt(agent: &Arc<Agent>, conn: &UnixStream, req: &AdoptRequest) -> Re
     let exit_code = *exit.0.lock().unwrap();
     framing::send_reply(
         conn,
-        &AdoptReply {
+        reply::Reply::Adopt(AdoptReply {
             pid,
             scratch_dir: build_dir.to_string_lossy().into_owned(),
             exit_code,
-        },
+        }),
         &[log.as_raw_fd()],
     )?;
     if exit_code.is_some() {
@@ -278,7 +276,7 @@ fn handle_kill(agent: &Arc<Agent>, conn: &UnixStream, req: &KillRequest) -> Resu
         }
     };
     agent.kill_sweep(Some(pid));
-    framing::send_reply(conn, &serde_json::json!({}), &[])
+    framing::send_reply(conn, reply::Reply::Empty(Empty {}), &[])
 }
 
 fn handle_finish(agent: &Arc<Agent>, conn: &UnixStream, req: &FinishRequest) -> Result<()> {
@@ -290,7 +288,7 @@ fn handle_finish(agent: &Arc<Agent>, conn: &UnixStream, req: &FinishRequest) -> 
         }
     };
     platform::finish(&agent.confinement, root.as_deref(), &outputs);
-    framing::send_reply(conn, &serde_json::json!({}), &[])
+    framing::send_reply(conn, reply::Reply::Empty(Empty {}), &[])
 }
 
 fn handle_cleanup(agent: &Arc<Agent>, conn: &UnixStream, req: &CleanupRequest) -> Result<()> {
@@ -303,7 +301,7 @@ fn handle_cleanup(agent: &Arc<Agent>, conn: &UnixStream, req: &CleanupRequest) -
     };
     agent.kill_sweep(Some(build.pid));
     platform::cleanup(&agent.confinement, &build);
-    framing::send_reply(conn, &serde_json::json!({}), &[])?;
+    framing::send_reply(conn, reply::Reply::Empty(Empty {}), &[])?;
     tracing::info!(id = build.id, "cleanup done");
     if agent.dedicated_uid {
         std::process::exit(0);
@@ -399,9 +397,9 @@ fn notify_exit(conn: &UnixStream, exit: &(Mutex<Option<i32>>, Condvar)) -> Resul
     }
     framing::send_reply(
         conn,
-        &ExitNotice {
+        reply::Reply::Exit(ExitNotice {
             exit_code: code.unwrap(),
-        },
+        }),
         &[],
     )
 }

--- a/crates/tribuchet/src/worker/agent/linux.rs
+++ b/crates/tribuchet/src/worker/agent/linux.rs
@@ -112,7 +112,7 @@ pub(super) fn spawn_builder(
     build_dir: &Path,
     log: &fs::File,
 ) -> Result<(Child, Option<PathBuf>)> {
-    let Some(sandbox_json) = &req.sandbox else {
+    let Some(sandbox_json) = &req.sandbox_json else {
         return Ok((super::spawn_plain(req, build_dir, log)?, None));
     };
     let userns = confinement
@@ -120,7 +120,7 @@ pub(super) fn spawn_builder(
         .as_ref()
         .context("sandboxed build requested but the agent has no --uid-base")?;
     let mut spec: SandboxSpec =
-        serde_json::from_value(sandbox_json.clone()).context("decoding the sandbox spec")?;
+        serde_json::from_str(sandbox_json).context("decoding the sandbox spec")?;
     spec.root = scratch_root.join("root");
     spec.build_dir = build_dir.to_path_buf();
     let (_ns_fd, ns_path) = userns::inherited_ns(&userns.fd)?;

--- a/crates/tribuchet/src/worker/agents.rs
+++ b/crates/tribuchet/src/worker/agents.rs
@@ -14,15 +14,12 @@ use std::sync::Mutex;
 #[cfg(target_os = "macos")]
 use std::fmt::Write as _;
 
-#[cfg(target_os = "macos")]
-use anyhow::bail;
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 #[cfg(target_os = "macos")]
 use sandbox_proto::agent::SCRATCH_DIR_PARAM;
 use sandbox_proto::agent::{
-    AdoptReply, AdoptRequest, CleanupRequest, ExitNotice, FinishRequest, KillRequest, METHOD_ADOPT,
-    METHOD_CLEANUP, METHOD_FINISH, METHOD_KILL, METHOD_START, METHOD_STATUS, StartReply,
-    StartRequest, StatusReply, StatusRequest,
+    AdoptRequest, CleanupRequest, FinishRequest, KillRequest, StartRequest, StatusRequest, call,
+    reply,
 };
 use sandbox_proto::framing;
 
@@ -151,8 +148,15 @@ impl AgentBuild {
     /// zstd tar of the build's tmp dir, passed as an fd.
     pub(super) fn start(socket: &Path, req: &StartRequest, tmp_tar: &fs::File) -> Result<Self> {
         let conn = connect(socket)?;
-        framing::send_call(&conn, METHOD_START, req, &[tmp_tar.as_raw_fd()])?;
-        let (reply, fds): (StartReply, _) = framing::recv_reply(&conn)?;
+        framing::send_call(
+            &conn,
+            call::Call::Start(Box::new(req.clone())),
+            &[tmp_tar.as_raw_fd()],
+        )?;
+        let (reply, fds) = framing::recv_reply(&conn)?;
+        let reply::Reply::Start(reply) = reply else {
+            bail!("unexpected agent reply {reply:?}");
+        };
         Ok(Self {
             conn,
             pid: reply.pid,
@@ -167,13 +171,15 @@ impl AgentBuild {
         let conn = connect(socket)?;
         framing::send_call(
             &conn,
-            METHOD_ADOPT,
-            &AdoptRequest {
+            call::Call::Adopt(AdoptRequest {
                 build_id: build_id.into(),
-            },
+            }),
             &[],
         )?;
-        let (reply, fds): (AdoptReply, _) = framing::recv_reply(&conn)?;
+        let (reply, fds) = framing::recv_reply(&conn)?;
+        let reply::Reply::Adopt(reply) = reply else {
+            bail!("unexpected agent reply {reply:?}");
+        };
         let build = Self {
             conn,
             pid: reply.pid,
@@ -185,7 +191,10 @@ impl AgentBuild {
 
     /// Block until the agent reports the builder's exit.
     pub(super) fn wait_exit(&self) -> Result<i32> {
-        let (notice, _): (ExitNotice, _) = framing::recv_reply(&self.conn)?;
+        let (reply, _) = framing::recv_reply(&self.conn)?;
+        let reply::Reply::Exit(notice) = reply else {
+            bail!("unexpected agent reply {reply:?}");
+        };
         Ok(notice.exit_code)
     }
 }
@@ -203,19 +212,22 @@ fn log_fd(fds: Vec<std::os::fd::OwnedFd>) -> Result<fs::File> {
     ))
 }
 
-/// Fire a control call that replies with an empty object.
-fn control<T: serde::Serialize>(socket: &Path, method: &str, req: &T) -> Result<()> {
+/// Fire a control call that replies with an empty message.
+fn control(socket: &Path, call: call::Call) -> Result<()> {
     let conn = connect(socket)?;
-    framing::send_call(&conn, method, req, &[])?;
-    let (_, _): (serde_json::Value, _) = framing::recv_reply(&conn)?;
+    framing::send_call(&conn, call, &[])?;
+    framing::recv_reply(&conn)?;
     Ok(())
 }
 
 /// The build the agent behind `socket` currently owns, if any.
 pub(super) fn current_build(socket: &Path) -> Result<Option<String>> {
     let conn = connect(socket)?;
-    framing::send_call(&conn, METHOD_STATUS, &StatusRequest {}, &[])?;
-    let (reply, _): (StatusReply, _) = framing::recv_reply(&conn)?;
+    framing::send_call(&conn, call::Call::Status(StatusRequest {}), &[])?;
+    let (reply, _) = framing::recv_reply(&conn)?;
+    let reply::Reply::Status(reply) = reply else {
+        bail!("unexpected agent reply {reply:?}");
+    };
     Ok(reply.current)
 }
 
@@ -223,10 +235,9 @@ pub(super) fn current_build(socket: &Path) -> Result<Option<String>> {
 pub(super) fn kill(socket: &Path, build_id: &str) -> Result<()> {
     control(
         socket,
-        METHOD_KILL,
-        &KillRequest {
+        call::Call::Kill(KillRequest {
             build_id: build_id.into(),
-        },
+        }),
     )
 }
 
@@ -234,10 +245,9 @@ pub(super) fn kill(socket: &Path, build_id: &str) -> Result<()> {
 pub(super) fn finish(socket: &Path, build_id: &str) -> Result<()> {
     control(
         socket,
-        METHOD_FINISH,
-        &FinishRequest {
+        call::Call::Finish(FinishRequest {
             build_id: build_id.into(),
-        },
+        }),
     )
 }
 
@@ -246,10 +256,9 @@ pub(super) fn finish(socket: &Path, build_id: &str) -> Result<()> {
 pub(super) fn cleanup(socket: &Path, build_id: &str) -> Result<()> {
     control(
         socket,
-        METHOD_CLEANUP,
-        &CleanupRequest {
+        call::Call::Cleanup(CleanupRequest {
             build_id: build_id.into(),
-        },
+        }),
     )
 }
 
@@ -301,7 +310,7 @@ mod tests {
             ]),
             tmp_dir_in_sandbox: "/build".into(),
             profile: String::new(),
-            sandbox: None,
+            sandbox_json: None,
             outputs,
             memory_max_bytes: None,
         }

--- a/crates/tribuchet/src/worker/build/agent_exec.rs
+++ b/crates/tribuchet/src/worker/build/agent_exec.rs
@@ -78,7 +78,7 @@ impl ActiveBuild {
         #[cfg(target_os = "linux")]
         let (profile, sandbox_json, mut spec) = {
             let spec = self.build_spec()?;
-            (String::new(), Some(serde_json::to_value(&spec)?), spec)
+            (String::new(), Some(serde_json::to_string(&spec)?), spec)
         };
         // Re-tar the staged tmp dir: the agent unpacks it into its own
         // scratch dir, since the worker's copy is not agent-writable.
@@ -93,7 +93,7 @@ impl ActiveBuild {
             env: a.env.clone(),
             tmp_dir_in_sandbox: a.tmp_dir_in_sandbox.clone(),
             profile,
-            sandbox: sandbox_json,
+            sandbox_json,
             outputs: outputs.clone(),
             memory_max_bytes: self.ctx.build_memory_max_bytes,
         };


### PR DESCRIPTION
The worker/agent protocol used ad-hoc JSON objects with a stringly
typed method field, dispatched and validated by hand on both sides.
Define the calls and replies in proto/agent.proto and frame prost
encoded Call/Reply envelopes instead; the oneof replaces the method
dispatch and malformed payloads are rejected by the decoder.

The framing (u32 length prefix plus SCM_RIGHTS fds over the unix
socket) is unchanged: fd passing is why this protocol exists and gRPC
cannot provide it. The Linux sandbox spec stays an opaque JSON string
inside StartRequest.