### PR TITLE
worker: let the builder write build.log directly

### DIFF
--- a/crates/tribuchet/src/worker/agent.rs
+++ b/crates/tribuchet/src/worker/agent.rs
@@ -5,14 +5,14 @@
 //! sending Start. The agent unpacks the tmp dir, confines the forked
 //! child (seatbelt on macOS) and execs the builder as its own
 //! (non-worker) uid. The builder is the agent's child, so builds
-//! survive worker restarts and the agent holds the log and exit
-//! status until the worker adopts them. The protocol lives in
+//! survive worker restarts and the agent holds the exit status until
+//! the worker adopts it. The build log goes to a worker-provided fd.
+//! The protocol lives in
 //! crates/sandbox-proto/proto/agent.proto.
 
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
-use std::os::fd::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Condvar, Mutex};
@@ -241,13 +241,12 @@ fn handle_start(
     if req.build_id.len() != 32 || !req.build_id.bytes().all(|b| b.is_ascii_hexdigit()) {
         return Err(msg(format!("invalid build id {:?}", req.build_id)));
     }
-    let tmp_pack = fds
-        .into_iter()
-        .next()
-        .ok_or_else(|| msg("missing tmp dir fd"))?;
+    let mut fds = fds.into_iter();
+    let tmp_pack = fds.next().ok_or_else(|| msg("missing tmp dir fd"))?;
+    let log_w = fs::File::from(fds.next().ok_or_else(|| msg("missing log fd"))?);
     // The lock is held until the build is registered: a losing
     // concurrent Start gets Busy without ever spawning anything.
-    let (build_dir, log, exit, pid) = {
+    let (build_dir, exit, pid) = {
         let mut current = agent.current.lock().unwrap();
         if current.is_some() {
             return Ok(framing::send_error(conn, ERROR_BUSY)?);
@@ -263,13 +262,17 @@ fn handle_start(
         platform::stage_tmp_dir(&agent.confinement, &scratch_root, &build_dir, tmp_pack)
             .map_err(|e| Error::StageTmpDir(Box::new(e)))?;
 
-        let log_path = scratch_root.join("build.log");
-        let log_w = fs::File::create(&log_path)?;
         let (child, sandbox_root) =
             platform::spawn_builder(&agent.confinement, &req, &scratch_root, &build_dir, &log_w)?;
         let pid = child.id().cast_signed();
         let exit = Arc::new((Mutex::new(None), Condvar::new()));
-        reap_on_exit(agent.clone(), req.build_id.clone(), child, exit.clone());
+        reap_on_exit(
+            agent.clone(),
+            req.build_id.clone(),
+            child,
+            log_w,
+            exit.clone(),
+        );
         *current = Some(Build {
             id: req.build_id.clone(),
             pid,
@@ -279,8 +282,7 @@ fn handle_start(
             outputs: req.outputs,
             exit: exit.clone(),
         });
-        // The worker only needs to read the log.
-        (build_dir, fs::File::open(&log_path)?, exit, pid)
+        (build_dir, exit, pid)
     };
     tracing::info!(id = req.build_id, pid, "builder started");
     framing::send_reply(
@@ -289,22 +291,19 @@ fn handle_start(
             pid,
             scratch_dir: build_dir.to_string_lossy().into_owned(),
         }),
-        &[log.as_raw_fd()],
+        &[],
     )?;
     notify_exit(conn, &exit)
 }
 
 fn handle_adopt(agent: &Arc<Agent>, conn: &UnixStream, req: &AdoptRequest) -> Result<(), Error> {
-    let (pid, build_dir, scratch_root, exit) = {
+    let (pid, build_dir, exit) = {
         let current = agent.current.lock().unwrap();
         match current.as_ref() {
-            Some(b) if b.id == req.build_id => {
-                (b.pid, b.dir.clone(), b.scratch_root.clone(), b.exit.clone())
-            }
+            Some(b) if b.id == req.build_id => (b.pid, b.dir.clone(), b.exit.clone()),
             _ => return Ok(framing::send_error(conn, ERROR_UNKNOWN_BUILD)?),
         }
     };
-    let log = fs::File::open(scratch_root.join("build.log"))?;
     let exit_code = *exit.0.lock().unwrap();
     framing::send_reply(
         conn,
@@ -313,7 +312,7 @@ fn handle_adopt(agent: &Arc<Agent>, conn: &UnixStream, req: &AdoptRequest) -> Re
             scratch_dir: build_dir.to_string_lossy().into_owned(),
             exit_code,
         }),
-        &[log.as_raw_fd()],
+        &[],
     )?;
     if exit_code.is_some() {
         return Ok(());
@@ -419,6 +418,7 @@ fn reap_on_exit(
     agent: Arc<Agent>,
     build_id: String,
     mut child: std::process::Child,
+    mut log: fs::File,
     exit: Arc<(Mutex<Option<i32>>, Condvar)>,
 ) {
     std::thread::spawn(move || {
@@ -431,13 +431,7 @@ fn reap_on_exit(
         };
         if platform::oom_killed(&agent.confinement, &build_id) {
             tracing::warn!(id = build_id, "builder killed by the build memory limit");
-            let log = agent.state_dir.join(&build_id).join("build.log");
-            let _ = fs::OpenOptions::new()
-                .append(true)
-                .open(log)
-                .and_then(|mut f| {
-                    f.write_all(b"tribuchet: builder killed by the build memory limit\n")
-                });
+            let _ = log.write_all(b"tribuchet: builder killed by the build memory limit\n");
         }
         tracing::info!(code, "builder exited");
         *exit.0.lock().unwrap() = Some(code);

--- a/crates/tribuchet/src/worker/agents.rs
+++ b/crates/tribuchet/src/worker/agents.rs
@@ -142,21 +142,26 @@ pub(super) struct AgentBuild {
     conn: UnixStream,
     pub(super) pid: i32,
     pub(super) scratch_dir: PathBuf,
-    /// Read handle on the agent-side log file.
-    pub(super) log: fs::File,
 }
 
 impl AgentBuild {
-    /// Start a build on the agent behind `socket`. `tmp_pack` is the
-    /// zstd entry stream of the build's tmp dir, passed as an fd.
-    pub(super) fn start(socket: &Path, req: &StartRequest, tmp_pack: &fs::File) -> Result<Self> {
+    /// Start a build on the agent behind `socket`. Two fds are
+    /// passed along: `tmp_pack` carries the zstd entry stream of the
+    /// build's tmp dir and `log` becomes the builder's stdout and
+    /// stderr.
+    pub(super) fn start(
+        socket: &Path,
+        req: &StartRequest,
+        tmp_pack: &fs::File,
+        log: &fs::File,
+    ) -> Result<Self> {
         let conn = connect(socket)?;
         framing::send_call(
             &conn,
             call::Call::Start(Box::new(req.clone())),
-            &[tmp_pack.as_raw_fd()],
+            &[tmp_pack.as_raw_fd(), log.as_raw_fd()],
         )?;
-        let (reply, fds) = framing::recv_reply(&conn)?;
+        let (reply, _fds) = framing::recv_reply(&conn)?;
         let reply::Reply::Start(reply) = reply else {
             return Err(err_msg(format!("unexpected agent reply {reply:?}")));
         };
@@ -164,7 +169,6 @@ impl AgentBuild {
             conn,
             pid: reply.pid,
             scratch_dir: PathBuf::from(reply.scratch_dir),
-            log: log_fd(fds)?,
         })
     }
 
@@ -179,7 +183,7 @@ impl AgentBuild {
             }),
             &[],
         )?;
-        let (reply, fds) = framing::recv_reply(&conn)?;
+        let (reply, _fds) = framing::recv_reply(&conn)?;
         let reply::Reply::Adopt(reply) = reply else {
             return Err(err_msg(format!("unexpected agent reply {reply:?}")));
         };
@@ -187,7 +191,6 @@ impl AgentBuild {
             conn,
             pid: reply.pid,
             scratch_dir: PathBuf::from(reply.scratch_dir),
-            log: log_fd(fds)?,
         };
         Ok((build, reply.exit_code))
     }
@@ -207,14 +210,6 @@ fn connect(socket: &Path) -> Result<UnixStream> {
         "connecting to the build agent at {}",
         socket.display()
     )))
-}
-
-fn log_fd(fds: Vec<std::os::fd::OwnedFd>) -> Result<fs::File> {
-    Ok(fs::File::from(
-        fds.into_iter()
-            .next()
-            .ok_or_else(|| err_msg("agent reply without a log fd"))?,
-    ))
 }
 
 /// Fire a control call that replies with an empty message.
@@ -271,7 +266,6 @@ pub(super) fn cleanup(socket: &Path, build_id: &str) -> Result<()> {
 mod tests {
     use super::*;
     use std::collections::HashMap;
-    use std::io::Read;
 
     /// A dev-mode agent (self-bound socket, same uid) plus a staged
     /// tmp dir pack for it, shared by the tests below.
@@ -341,13 +335,16 @@ mod tests {
             ),
             vec![output.to_string_lossy().into_owned()],
         );
-        let build = AgentBuild::start(&socket, &req, &fs::File::open(&pack_path)?)?;
+        let log_path = dir.path().join("build.log");
+        let log_w = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)?;
+        let build = AgentBuild::start(&socket, &req, &fs::File::open(&pack_path)?, &log_w)?;
         assert!(build.pid > 0);
         assert_eq!(build.wait_exit()?, 0);
 
-        let mut log = String::new();
-        let mut log_file = build.log;
-        log_file.read_to_string(&mut log)?;
+        let log = fs::read_to_string(&log_path)?;
         assert!(log.contains("built"), "log: {log}");
 
         let (_, exit) = AgentBuild::adopt(&socket, build_id)?;

--- a/crates/tribuchet/src/worker/build.rs
+++ b/crates/tribuchet/src/worker/build.rs
@@ -849,7 +849,7 @@ impl<W: Write> Write for TeeScanner<'_, W> {
 
 #[path = "build/agent_exec.rs"]
 mod agent_exec;
-pub(super) use agent_exec::{LogMirror, supervise_agent};
+pub(super) use agent_exec::supervise_agent;
 
 #[cfg(test)]
 mod tests {

--- a/crates/tribuchet/src/worker/build/agent_exec.rs
+++ b/crates/tribuchet/src/worker/build/agent_exec.rs
@@ -5,11 +5,11 @@
 //! Linux the serialized sandbox spec the agent runs the setup stage
 //! with.
 
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{self, Ordering};
 use std::time::{Duration, Instant};
-use std::{fs, io};
 
 use harmonia_utils_signature::SecretKey;
 use tokio::sync::mpsc;
@@ -97,11 +97,19 @@ impl ActiveBuild {
             outputs: outputs.clone(),
             memory_max_bytes: self.ctx.build_memory_max_bytes,
         };
+        // The builder writes dir/build.log directly through this fd.
+        // Tailing, replay and the abort heuristics read the same file.
+        let log_w = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(self.dir.join("build.log"))?;
         let build = agents::AgentBuild::start(
             socket,
             &req,
             &fs::File::open(self.dir.join("top.tmpdir.zst"))?,
+            &log_w,
         )?;
+        drop(log_w);
         tracing::info!(
             id = a.build_id,
             pid = build.pid,
@@ -120,10 +128,6 @@ impl ActiveBuild {
                 .join("root");
         }
 
-        // Mirror the agent-side log into dir/build.log so the
-        // path-based tailing, replay and resume machinery keeps
-        // working across worker restarts.
-        let mirror = LogMirror::start(&build.log, self.dir.join("build.log"))?;
         let log_done = Arc::new(atomic::AtomicBool::new(false));
         let tailer = {
             let tx = out_tx.clone();
@@ -153,9 +157,6 @@ impl ActiveBuild {
             build,
             signing_key,
         );
-        // The mirror is drained before the tailer's final read so no
-        // trailing log lines are lost.
-        mirror.stop();
         log_done.store(true, Ordering::Relaxed);
         let _ = tailer.join();
         Ok(fin)
@@ -285,63 +286,5 @@ pub(in crate::worker) fn supervise_agent(
         extras,
         dir,
         finished_at: Instant::now(),
-    }
-}
-
-/// Background thread appending everything the agent writes to its log
-/// fd into the build dir's build.log, feeding the path-based tailing,
-/// replay and resume machinery.
-pub(in crate::worker) struct LogMirror {
-    done: Arc<atomic::AtomicBool>,
-    thread: std::thread::JoinHandle<()>,
-}
-
-impl LogMirror {
-    /// Start mirroring `log` into `dest_path`, appending where a
-    /// previous worker generation's mirror left off.
-    pub(in crate::worker) fn start(log: &fs::File, dest_path: PathBuf) -> Result<Self> {
-        let mut src = log.try_clone()?;
-        let done = Arc::new(atomic::AtomicBool::new(false));
-        let thread = {
-            let done = done.clone();
-            std::thread::spawn(move || {
-                use std::io::{Read as _, Seek as _, Write as _};
-                let Ok(mut dest) = fs::OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(&dest_path)
-                else {
-                    return;
-                };
-                let already = dest.metadata().map_or(0, |m| m.len());
-                if src.seek(io::SeekFrom::Start(already)).is_err() {
-                    return;
-                }
-                let mut buf = [0u8; 8192];
-                loop {
-                    match src.read(&mut buf) {
-                        Ok(0) => {
-                            if done.load(Ordering::Relaxed) {
-                                return;
-                            }
-                            std::thread::sleep(Duration::from_millis(200));
-                        }
-                        Ok(n) => {
-                            if dest.write_all(&buf[..n]).is_err() {
-                                return;
-                            }
-                        }
-                        Err(_) => return,
-                    }
-                }
-            })
-        };
-        Ok(Self { done, thread })
-    }
-
-    /// Drain what is still buffered agent-side, then stop.
-    pub(in crate::worker) fn stop(self) {
-        self.done.store(true, Ordering::Relaxed);
-        let _ = self.thread.join();
     }
 }

--- a/crates/tribuchet/src/worker/logtail.rs
+++ b/crates/tribuchet/src/worker/logtail.rs
@@ -24,64 +24,76 @@ impl LogTail {
     }
 }
 
-/// How far of `dir`'s build.log has already been streamed to a hub.
-/// Persisted next to the log so resumed sessions and later worker
-/// generations continue where the previous tailer stopped instead of
-/// repeating the log from the start.
-fn read_log_offset(dir: &Path) -> u64 {
-    std::fs::read_to_string(dir.join("log.offset"))
-        .ok()
-        .and_then(|s| s.trim().parse().ok())
-        .unwrap_or(0)
+/// Read position in a build dir's build.log. It is persisted as
+/// log.offset so resumed sessions and later worker generations
+/// continue where the previous tailer stopped.
+struct LogCursor {
+    file: std::fs::File,
+    dir: PathBuf,
+    sent: u64,
 }
 
-fn write_log_offset(dir: &Path, offset: u64) {
-    let _ = std::fs::write(dir.join("log.offset"), offset.to_string());
+impl LogCursor {
+    /// Open build.log at the persisted offset. A missing file means
+    /// the build never started a builder, so there is no cursor.
+    fn open(dir: &Path) -> Option<Self> {
+        use std::io::Seek;
+        let mut file = std::fs::File::open(dir.join("build.log")).ok()?;
+        let sent = std::fs::read_to_string(dir.join("log.offset"))
+            .ok()
+            .and_then(|s| s.trim().parse().ok())
+            .unwrap_or(0);
+        file.seek(std::io::SeekFrom::Start(sent)).ok()?;
+        Some(Self {
+            file,
+            dir: dir.to_path_buf(),
+            sent,
+        })
+    }
+
+    /// Read to EOF and persist the offset after every accepted
+    /// chunk. Returns false when `emit` rejects a chunk or the file
+    /// breaks.
+    fn drain(&mut self, mut emit: impl FnMut(Vec<u8>) -> bool) -> bool {
+        let mut buf = [0u8; 8192];
+        loop {
+            match self.file.read(&mut buf) {
+                Ok(0) => return true,
+                Err(_) => return false,
+                Ok(n) => {
+                    if !emit(buf[..n].to_vec()) {
+                        return false;
+                    }
+                    self.sent += n as u64;
+                    let _ = std::fs::write(self.dir.join("log.offset"), self.sent.to_string());
+                }
+            }
+        }
+    }
 }
 
-/// Stream `dir`'s build.log to `out_tx` as LogChunks for `build_id`,
-/// starting at the persisted offset and advancing it after every
-/// chunk handed to the session. Polls past EOF until `done()` says
-/// nothing more can arrive (one final read has then already drained
-/// what was flushed); a failed send ends it, the offset stays put.
+/// Stream `dir`'s build.log to `out_tx` as LogChunks for `build_id`.
+/// Keeps polling past EOF until `done()` reports that nothing more
+/// can arrive.
 pub(super) fn tail_log(
     dir: &Path,
     build_id: &str,
     out_tx: &mpsc::Sender<WorkerMessage>,
     done: impl Fn() -> bool,
 ) {
-    use std::io::Seek;
-    let Ok(mut file) = std::fs::File::open(dir.join("build.log")) else {
+    let Some(mut cursor) = LogCursor::open(dir) else {
         return;
     };
-    let mut sent = read_log_offset(dir);
-    if file.seek(std::io::SeekFrom::Start(sent)).is_err() {
-        return;
-    }
-    let mut buf = [0u8; 8192];
-    loop {
-        match file.read(&mut buf) {
-            Ok(0) => {
-                if done() {
-                    break;
-                }
-                std::thread::sleep(std::time::Duration::from_millis(100));
-            }
-            Err(_) => break,
-            Ok(n) => {
-                if out_tx
-                    .blocking_send(msg(worker_message::Msg::Log(LogChunk {
-                        build_id: build_id.into(),
-                        data: buf[..n].to_vec(),
-                    })))
-                    .is_err()
-                {
-                    break;
-                }
-                sent += n as u64;
-                write_log_offset(dir, sent);
-            }
-        }
+    let mut emit = |data| {
+        out_tx
+            .blocking_send(msg(worker_message::Msg::Log(LogChunk {
+                build_id: build_id.into(),
+                data,
+            })))
+            .is_ok()
+    };
+    while cursor.drain(&mut emit) && !done() {
+        std::thread::sleep(std::time::Duration::from_millis(100));
     }
 }
 
@@ -107,4 +119,47 @@ pub(super) fn spawn_log_tail(
         tail_log(&dir, &build_id, &out_tx, done);
     });
     LogTail { done, handle }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn offset(dir: &Path) -> u64 {
+        std::fs::read_to_string(dir.join("log.offset"))
+            .unwrap()
+            .parse()
+            .unwrap()
+    }
+
+    #[test]
+    fn cursor_resumes_at_persisted_offset() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("build.log"), b"old-new").unwrap();
+        std::fs::write(dir.path().join("log.offset"), "4").unwrap();
+        let mut cursor = LogCursor::open(dir.path()).unwrap();
+        let mut got = Vec::new();
+        assert!(cursor.drain(|d| {
+            got.extend(d);
+            true
+        }));
+        assert_eq!(got, b"new");
+        assert_eq!(offset(dir.path()), 7);
+    }
+
+    #[test]
+    fn rejected_chunk_keeps_offset_for_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("build.log"), b"hello").unwrap();
+        std::fs::write(dir.path().join("log.offset"), "0").unwrap();
+        let mut cursor = LogCursor::open(dir.path()).unwrap();
+        assert!(!cursor.drain(|_| false));
+        assert_eq!(offset(dir.path()), 0);
+    }
+
+    #[test]
+    fn missing_log_means_no_cursor() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(LogCursor::open(dir.path()).is_none());
+    }
 }

--- a/crates/tribuchet/src/worker/resume.rs
+++ b/crates/tribuchet/src/worker/resume.rs
@@ -12,7 +12,7 @@ use harmonia_utils_signature::SecretKey;
 use tokio::sync::mpsc;
 
 use super::build::ActiveBuild;
-use super::build::{LogMirror, supervise_agent};
+use super::build::supervise_agent;
 use super::logtail::LogTail;
 use super::{DaemonConn, WorkerCtx, msg, sandbox};
 use crate::chunkio::CHUNK_SIZE;
@@ -91,13 +91,7 @@ pub(super) async fn adopt_builds(ctx: &Arc<WorkerCtx>, signing_key: &Arc<SecretK
             let key = st.dedupe_key.clone();
             let fin = {
                 let (socket, build) = agent;
-                // Keep mirroring the agent-side log into dir/build.log
-                // so replay and abort heuristics see fresh data.
-                let mirror = LogMirror::start(&build.log, dir.join("build.log")).ok();
                 let fin = supervise_agent(&ctx, &st, dir, &socket, build, &signing_key);
-                if let Some(m) = mirror {
-                    m.stop();
-                }
                 ctx.agents.release(socket);
                 fin
             };


### PR DESCRIPTION

Whole build logs went missing when the tailer thread started before
LogMirror's thread created dir/build.log: the tailer exited silently
and nix logs showed nothing but the dispatch line.

Remove the mirror instead of patching the race. The worker creates
builds/<id>/build.log up front and passes a write fd in the Start
call, so the builder writes the one file that tailing, replay, resume
and the abort heuristics already read.

Start now carries the log fd and the replies no longer return one, so
workers and agents must be updated together.
