### PR TITLE
worker: let the builder write build.log directly

### DIFF
--- a/crates/tribuchet/src/config.rs
+++ b/crates/tribuchet/src/config.rs
@@ -225,7 +225,7 @@ impl WorkerConfig {
 }
 
 fn default_state_dir() -> PathBuf {
-    "/var/lib/tribuchet".into()
+    "/var/lib/tribuchet/worker".into()
 }
 fn default_ca_cert() -> PathBuf {
     "/var/lib/tribuchet/tls/ca.crt".into()
@@ -275,7 +275,7 @@ mod tests {
         assert_eq!(cfg.hub, "https://hub:7437");
         assert_eq!(cfg.max_jobs, 2);
         assert_eq!(cfg.build_timeout_secs, 24 * 3600);
-        assert_eq!(cfg.state_dir, PathBuf::from("/var/lib/tribuchet"));
+        assert_eq!(cfg.state_dir, PathBuf::from("/var/lib/tribuchet/worker"));
         assert_eq!(
             cfg.emulate.get("aarch64-linux"),
             Some(&PathBuf::from("/nix/store/x-qemu/bin/qemu-aarch64"))

--- a/crates/tribuchet/src/hub/state.rs
+++ b/crates/tribuchet/src/hub/state.rs
@@ -72,7 +72,14 @@ impl Replay {
         let mut inner = self.inner.lock().await;
         // try_send: a subscriber that stopped reading is dropped (its
         // attach errors out) instead of buffering unboundedly.
-        inner.subs.retain(|tx| tx.try_send(Ok(ev.clone())).is_ok());
+        inner.subs.retain(|tx| match tx.try_send(Ok(ev.clone())) {
+            Ok(()) => true,
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                tracing::warn!("dropping attach subscriber that fell too far behind");
+                false
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => false,
+        });
         if inner.overflowed {
             return;
         }

--- a/crates/tribuchet/src/main.rs
+++ b/crates/tribuchet/src/main.rs
@@ -11,6 +11,7 @@ mod netpolicy;
 mod proto;
 mod rt;
 mod sd;
+mod sockpath;
 mod store;
 mod tailscale;
 mod tmpdir;

--- a/crates/tribuchet/src/sockpath.rs
+++ b/crates/tribuchet/src/sockpath.rs
@@ -1,0 +1,63 @@
+//! Unix socket bind/connect that tolerate paths beyond the sun_path
+//! limit by chdir'ing into the parent and using the bare filename,
+//! like Nix does. The process-global chdir is guarded by a lock.
+
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::Path;
+use std::sync::Mutex;
+
+static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+pub fn bind(path: &Path) -> std::io::Result<UnixListener> {
+    match UnixListener::bind(path) {
+        Err(e) if too_long(&e) => in_parent_dir(path, |p| UnixListener::bind(p)),
+        res => res,
+    }
+}
+
+pub fn connect(path: &Path) -> std::io::Result<UnixStream> {
+    match UnixStream::connect(path) {
+        Err(e) if too_long(&e) => in_parent_dir(path, |p| UnixStream::connect(p)),
+        res => res,
+    }
+}
+
+fn too_long(e: &std::io::Error) -> bool {
+    // Rust reports an over-long path as InvalidInput before the syscall.
+    e.kind() == std::io::ErrorKind::InvalidInput || e.raw_os_error() == Some(libc::ENAMETOOLONG)
+}
+
+fn in_parent_dir<T>(
+    path: &Path,
+    f: impl FnOnce(&Path) -> std::io::Result<T>,
+) -> std::io::Result<T> {
+    let err = || std::io::Error::new(std::io::ErrorKind::InvalidInput, "socket path unusable");
+    let parent = path.parent().filter(|p| !p.as_os_str().is_empty());
+    let (Some(parent), Some(name)) = (parent, path.file_name()) else {
+        return Err(err());
+    };
+    let _guard = CWD_LOCK.lock().unwrap();
+    let old = std::env::current_dir()?;
+    std::env::set_current_dir(parent)?;
+    let res = f(Path::new(name));
+    let _ = std::env::set_current_dir(old);
+    res
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn long_socket_paths_bind_and_connect() {
+        let dir = tempfile::tempdir().unwrap();
+        let deep = dir.path().join("a".repeat(60)).join("b".repeat(60));
+        std::fs::create_dir_all(&deep).unwrap();
+        let sock = deep.join("agent.sock");
+        assert!(sock.as_os_str().len() > 104);
+        let listener = bind(&sock).unwrap();
+        let client = std::thread::spawn(move || connect(&sock).unwrap());
+        listener.accept().unwrap();
+        client.join().unwrap();
+    }
+}

--- a/crates/tribuchet/src/worker/agent.rs
+++ b/crates/tribuchet/src/worker/agent.rs
@@ -5,14 +5,14 @@
 //! sending Start. The agent unpacks the tmp dir, confines the forked
 //! child (seatbelt on macOS) and execs the builder as its own
 //! (non-worker) uid. The builder is the agent's child, so builds
-//! survive worker restarts and the agent holds the log and exit
-//! status until the worker adopts them. The protocol lives in
+//! survive worker restarts and the agent holds the exit status until
+//! the worker adopts it. The build log goes to a worker-provided fd.
+//! The protocol lives in
 //! crates/sandbox-proto/proto/agent.proto.
 
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
-use std::os::fd::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Condvar, Mutex};
@@ -241,13 +241,12 @@ fn handle_start(
     if req.build_id.len() != 32 || !req.build_id.bytes().all(|b| b.is_ascii_hexdigit()) {
         return Err(msg(format!("invalid build id {:?}", req.build_id)));
     }
-    let tmp_pack = fds
-        .into_iter()
-        .next()
-        .ok_or_else(|| msg("missing tmp dir fd"))?;
+    let mut fds = fds.into_iter();
+    let tmp_pack = fds.next().ok_or_else(|| msg("missing tmp dir fd"))?;
+    let log_w = fs::File::from(fds.next().ok_or_else(|| msg("missing log fd"))?);
     // The lock is held until the build is registered: a losing
     // concurrent Start gets Busy without ever spawning anything.
-    let (build_dir, log, exit, pid) = {
+    let (build_dir, exit, pid) = {
         let mut current = agent.current.lock().unwrap();
         if current.is_some() {
             return Ok(framing::send_error(conn, ERROR_BUSY)?);
@@ -263,13 +262,17 @@ fn handle_start(
         platform::stage_tmp_dir(&agent.confinement, &scratch_root, &build_dir, tmp_pack)
             .map_err(|e| Error::StageTmpDir(Box::new(e)))?;
 
-        let log_path = scratch_root.join("build.log");
-        let log_w = fs::File::create(&log_path)?;
         let (child, sandbox_root) =
             platform::spawn_builder(&agent.confinement, &req, &scratch_root, &build_dir, &log_w)?;
         let pid = child.id().cast_signed();
         let exit = Arc::new((Mutex::new(None), Condvar::new()));
-        reap_on_exit(agent.clone(), req.build_id.clone(), child, exit.clone());
+        reap_on_exit(
+            agent.clone(),
+            req.build_id.clone(),
+            child,
+            log_w,
+            exit.clone(),
+        );
         *current = Some(Build {
             id: req.build_id.clone(),
             pid,
@@ -279,8 +282,7 @@ fn handle_start(
             outputs: req.outputs,
             exit: exit.clone(),
         });
-        // The worker only needs to read the log.
-        (build_dir, fs::File::open(&log_path)?, exit, pid)
+        (build_dir, exit, pid)
     };
     tracing::info!(id = req.build_id, pid, "builder started");
     framing::send_reply(
@@ -289,22 +291,19 @@ fn handle_start(
             pid,
             scratch_dir: build_dir.to_string_lossy().into_owned(),
         }),
-        &[log.as_raw_fd()],
+        &[],
     )?;
     notify_exit(conn, &exit)
 }
 
 fn handle_adopt(agent: &Arc<Agent>, conn: &UnixStream, req: &AdoptRequest) -> Result<(), Error> {
-    let (pid, build_dir, scratch_root, exit) = {
+    let (pid, build_dir, exit) = {
         let current = agent.current.lock().unwrap();
         match current.as_ref() {
-            Some(b) if b.id == req.build_id => {
-                (b.pid, b.dir.clone(), b.scratch_root.clone(), b.exit.clone())
-            }
+            Some(b) if b.id == req.build_id => (b.pid, b.dir.clone(), b.exit.clone()),
             _ => return Ok(framing::send_error(conn, ERROR_UNKNOWN_BUILD)?),
         }
     };
-    let log = fs::File::open(scratch_root.join("build.log"))?;
     let exit_code = *exit.0.lock().unwrap();
     framing::send_reply(
         conn,
@@ -313,7 +312,7 @@ fn handle_adopt(agent: &Arc<Agent>, conn: &UnixStream, req: &AdoptRequest) -> Re
             scratch_dir: build_dir.to_string_lossy().into_owned(),
             exit_code,
         }),
-        &[log.as_raw_fd()],
+        &[],
     )?;
     if exit_code.is_some() {
         return Ok(());
@@ -419,6 +418,7 @@ fn reap_on_exit(
     agent: Arc<Agent>,
     build_id: String,
     mut child: std::process::Child,
+    mut log: fs::File,
     exit: Arc<(Mutex<Option<i32>>, Condvar)>,
 ) {
     std::thread::spawn(move || {
@@ -431,13 +431,7 @@ fn reap_on_exit(
         };
         if platform::oom_killed(&agent.confinement, &build_id) {
             tracing::warn!(id = build_id, "builder killed by the build memory limit");
-            let log = agent.state_dir.join(&build_id).join("build.log");
-            let _ = fs::OpenOptions::new()
-                .append(true)
-                .open(log)
-                .and_then(|mut f| {
-                    f.write_all(b"tribuchet: builder killed by the build memory limit\n")
-                });
+            let _ = log.write_all(b"tribuchet: builder killed by the build memory limit\n");
         }
         tracing::info!(code, "builder exited");
         *exit.0.lock().unwrap() = Some(code);

--- a/crates/tribuchet/src/worker/agent.rs
+++ b/crates/tribuchet/src/worker/agent.rs
@@ -124,9 +124,9 @@ struct Build {
     id: String,
     /// Builder pid, also its process group.
     pid: i32,
-    /// Scratch dir the build runs in (`<state>/<id>/build`).
+    /// Scratch dir the build runs in (`<state>/scratch/build`).
     dir: PathBuf,
-    /// Whole per-build tree removed by Cleanup (`<state>/<id>`).
+    /// Whole per-build tree removed by Cleanup (`<state>/scratch`).
     scratch_root: PathBuf,
     /// Private sandbox root under the scratch dir (Linux namespace
     /// builds); outputs land below it instead of at their store paths.
@@ -255,7 +255,9 @@ fn handle_start(
         // not tamper with this one. The uid holds nothing else.
         agent.kill_sweep(None);
 
-        let scratch_root = agent.state_dir.join(&req.build_id);
+        // Fixed short name keeps in-sandbox socket paths within
+        // sun_path limits. Identity lives in agent memory.
+        let scratch_root = agent.state_dir.join("scratch");
         let build_dir = scratch_root.join("build");
         let _ = fs::remove_dir_all(&scratch_root);
         fs::create_dir_all(&scratch_root)?;

--- a/crates/tribuchet/src/worker/agent.rs
+++ b/crates/tribuchet/src/worker/agent.rs
@@ -205,7 +205,7 @@ fn listener(socket: Option<&Path>) -> Result<(UnixListener, bool), Error> {
     }
     let path = socket.ok_or_else(|| msg("no activated socket and no --socket given"))?;
     let _ = fs::remove_file(path);
-    let l = UnixListener::bind(path).map_err(step(format!("binding {}", path.display())))?;
+    let l = crate::sockpath::bind(path).map_err(step(format!("binding {}", path.display())))?;
     Ok((l, false))
 }
 

--- a/crates/tribuchet/src/worker/agent_spawn.rs
+++ b/crates/tribuchet/src/worker/agent_spawn.rs
@@ -3,7 +3,6 @@
 //! slot, supervises it and restarts it after it exits.
 
 use std::fs;
-use std::os::unix::net::UnixStream;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -174,7 +173,7 @@ fn wait_for_sockets(sockets: &[PathBuf]) -> Result<(), Error> {
     let deadline = Instant::now() + Duration::from_secs(30);
     for socket in sockets {
         loop {
-            if UnixStream::connect(socket).is_ok() {
+            if crate::sockpath::connect(socket).is_ok() {
                 break;
             }
             if Instant::now() >= deadline {

--- a/crates/tribuchet/src/worker/agents.rs
+++ b/crates/tribuchet/src/worker/agents.rs
@@ -206,7 +206,7 @@ impl AgentBuild {
 }
 
 fn connect(socket: &Path) -> Result<UnixStream> {
-    UnixStream::connect(socket).map_err(err_ctx(format!(
+    crate::sockpath::connect(socket).map_err(err_ctx(format!(
         "connecting to the build agent at {}",
         socket.display()
     )))

--- a/crates/tribuchet/src/worker/agents.rs
+++ b/crates/tribuchet/src/worker/agents.rs
@@ -142,21 +142,26 @@ pub(super) struct AgentBuild {
     conn: UnixStream,
     pub(super) pid: i32,
     pub(super) scratch_dir: PathBuf,
-    /// Read handle on the agent-side log file.
-    pub(super) log: fs::File,
 }
 
 impl AgentBuild {
-    /// Start a build on the agent behind `socket`. `tmp_pack` is the
-    /// zstd entry stream of the build's tmp dir, passed as an fd.
-    pub(super) fn start(socket: &Path, req: &StartRequest, tmp_pack: &fs::File) -> Result<Self> {
+    /// Start a build on the agent behind `socket`. Two fds are
+    /// passed along: `tmp_pack` carries the zstd entry stream of the
+    /// build's tmp dir and `log` becomes the builder's stdout and
+    /// stderr.
+    pub(super) fn start(
+        socket: &Path,
+        req: &StartRequest,
+        tmp_pack: &fs::File,
+        log: &fs::File,
+    ) -> Result<Self> {
         let conn = connect(socket)?;
         framing::send_call(
             &conn,
             call::Call::Start(Box::new(req.clone())),
-            &[tmp_pack.as_raw_fd()],
+            &[tmp_pack.as_raw_fd(), log.as_raw_fd()],
         )?;
-        let (reply, fds) = framing::recv_reply(&conn)?;
+        let (reply, _fds) = framing::recv_reply(&conn)?;
         let reply::Reply::Start(reply) = reply else {
             return Err(err_msg(format!("unexpected agent reply {reply:?}")));
         };
@@ -164,7 +169,6 @@ impl AgentBuild {
             conn,
             pid: reply.pid,
             scratch_dir: PathBuf::from(reply.scratch_dir),
-            log: log_fd(fds)?,
         })
     }
 
@@ -179,7 +183,7 @@ impl AgentBuild {
             }),
             &[],
         )?;
-        let (reply, fds) = framing::recv_reply(&conn)?;
+        let (reply, _fds) = framing::recv_reply(&conn)?;
         let reply::Reply::Adopt(reply) = reply else {
             return Err(err_msg(format!("unexpected agent reply {reply:?}")));
         };
@@ -187,7 +191,6 @@ impl AgentBuild {
             conn,
             pid: reply.pid,
             scratch_dir: PathBuf::from(reply.scratch_dir),
-            log: log_fd(fds)?,
         };
         Ok((build, reply.exit_code))
     }
@@ -207,14 +210,6 @@ fn connect(socket: &Path) -> Result<UnixStream> {
         "connecting to the build agent at {}",
         socket.display()
     )))
-}
-
-fn log_fd(fds: Vec<std::os::fd::OwnedFd>) -> Result<fs::File> {
-    Ok(fs::File::from(
-        fds.into_iter()
-            .next()
-            .ok_or_else(|| err_msg("agent reply without a log fd"))?,
-    ))
 }
 
 /// Fire a control call that replies with an empty message.
@@ -271,7 +266,6 @@ pub(super) fn cleanup(socket: &Path, build_id: &str) -> Result<()> {
 mod tests {
     use super::*;
     use std::collections::HashMap;
-    use std::io::Read;
 
     /// A dev-mode agent (self-bound socket, same uid) plus a staged
     /// tmp dir pack for it, shared by the tests below.
@@ -341,13 +335,16 @@ mod tests {
             ),
             vec![output.to_string_lossy().into_owned()],
         );
-        let build = AgentBuild::start(&socket, &req, &fs::File::open(&pack_path)?)?;
+        let log_path = dir.path().join("build.log");
+        let log_w = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)?;
+        let build = AgentBuild::start(&socket, &req, &fs::File::open(&pack_path)?, &log_w)?;
         assert!(build.pid > 0);
         assert_eq!(build.wait_exit()?, 0);
 
-        let mut log = String::new();
-        let mut log_file = build.log;
-        log_file.read_to_string(&mut log)?;
+        let log = fs::read_to_string(&log_path)?;
         assert!(log.contains("built"), "log: {log}");
 
         let (_, exit) = AgentBuild::adopt(&socket, build_id)?;
@@ -399,7 +396,11 @@ mod tests {
             outputs.clone(),
         );
         req.profile = seatbelt_profile(&outputs, &[secret], false)?;
-        let build = AgentBuild::start(&socket, &req, &fs::File::open(&pack_path)?)?;
+        let log_w = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(dir_path.join("build.log"))?;
+        let build = AgentBuild::start(&socket, &req, &fs::File::open(&pack_path)?, &log_w)?;
         assert_eq!(build.wait_exit()?, 0);
         assert!(!outside.exists());
         finish(&socket, build_id)?;

--- a/crates/tribuchet/src/worker/build.rs
+++ b/crates/tribuchet/src/worker/build.rs
@@ -849,7 +849,7 @@ impl<W: Write> Write for TeeScanner<'_, W> {
 
 #[path = "build/agent_exec.rs"]
 mod agent_exec;
-pub(super) use agent_exec::{LogMirror, supervise_agent};
+pub(super) use agent_exec::supervise_agent;
 
 #[cfg(test)]
 mod tests {

--- a/crates/tribuchet/src/worker/build/agent_exec.rs
+++ b/crates/tribuchet/src/worker/build/agent_exec.rs
@@ -5,11 +5,11 @@
 //! Linux the serialized sandbox spec the agent runs the setup stage
 //! with.
 
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{self, Ordering};
 use std::time::{Duration, Instant};
-use std::{fs, io};
 
 use harmonia_utils_signature::SecretKey;
 use tokio::sync::mpsc;
@@ -97,11 +97,19 @@ impl ActiveBuild {
             outputs: outputs.clone(),
             memory_max_bytes: self.ctx.build_memory_max_bytes,
         };
+        // The builder writes dir/build.log directly through this fd.
+        // Tailing, replay and the abort heuristics read the same file.
+        let log_w = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(self.dir.join("build.log"))?;
         let build = agents::AgentBuild::start(
             socket,
             &req,
             &fs::File::open(self.dir.join("top.tmpdir.zst"))?,
+            &log_w,
         )?;
+        drop(log_w);
         tracing::info!(
             id = a.build_id,
             pid = build.pid,
@@ -120,10 +128,6 @@ impl ActiveBuild {
                 .join("root");
         }
 
-        // Mirror the agent-side log into dir/build.log so the
-        // path-based tailing, replay and resume machinery keeps
-        // working across worker restarts.
-        let mirror = LogMirror::start(&build.log, self.dir.join("build.log"))?;
         let log_done = Arc::new(atomic::AtomicBool::new(false));
         let tailer = {
             let tx = out_tx.clone();
@@ -153,9 +157,6 @@ impl ActiveBuild {
             build,
             signing_key,
         );
-        // The mirror is drained before the tailer's final read so no
-        // trailing log lines are lost.
-        mirror.stop();
         log_done.store(true, Ordering::Relaxed);
         let _ = tailer.join();
         Ok(fin)
@@ -285,63 +286,5 @@ pub(in crate::worker) fn supervise_agent(
         extras,
         dir,
         finished_at: Instant::now(),
-    }
-}
-
-/// Background thread appending everything the agent writes to its log
-/// fd into the build dir's build.log, feeding the path-based tailing,
-/// replay and resume machinery.
-pub(in crate::worker) struct LogMirror {
-    done: Arc<atomic::AtomicBool>,
-    thread: std::thread::JoinHandle<()>,
-}
-
-impl LogMirror {
-    /// Start mirroring `log` into `dest_path`, appending where a
-    /// previous worker generation's mirror left off.
-    pub(in crate::worker) fn start(log: &fs::File, dest_path: PathBuf) -> Result<Self> {
-        let mut src = log.try_clone()?;
-        let done = Arc::new(atomic::AtomicBool::new(false));
-        let thread = {
-            let done = done.clone();
-            std::thread::spawn(move || {
-                use std::io::{Read as _, Seek as _, Write as _};
-                let Ok(mut dest) = fs::OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(&dest_path)
-                else {
-                    return;
-                };
-                let already = dest.metadata().map_or(0, |m| m.len());
-                if src.seek(io::SeekFrom::Start(already)).is_err() {
-                    return;
-                }
-                let mut buf = [0u8; 8192];
-                loop {
-                    match src.read(&mut buf) {
-                        Ok(0) => {
-                            if done.load(Ordering::Relaxed) {
-                                return;
-                            }
-                            std::thread::sleep(Duration::from_millis(200));
-                        }
-                        Ok(n) => {
-                            if dest.write_all(&buf[..n]).is_err() {
-                                return;
-                            }
-                        }
-                        Err(_) => return,
-                    }
-                }
-            })
-        };
-        Ok(Self { done, thread })
-    }
-
-    /// Drain what is still buffered agent-side, then stop.
-    pub(in crate::worker) fn stop(self) {
-        self.done.store(true, Ordering::Relaxed);
-        let _ = self.thread.join();
     }
 }

--- a/crates/tribuchet/src/worker/logtail.rs
+++ b/crates/tribuchet/src/worker/logtail.rs
@@ -24,64 +24,76 @@ impl LogTail {
     }
 }
 
-/// How far of `dir`'s build.log has already been streamed to a hub.
-/// Persisted next to the log so resumed sessions and later worker
-/// generations continue where the previous tailer stopped instead of
-/// repeating the log from the start.
-fn read_log_offset(dir: &Path) -> u64 {
-    std::fs::read_to_string(dir.join("log.offset"))
-        .ok()
-        .and_then(|s| s.trim().parse().ok())
-        .unwrap_or(0)
+/// Read position in a build dir's build.log. It is persisted as
+/// log.offset so resumed sessions and later worker generations
+/// continue where the previous tailer stopped.
+struct LogCursor {
+    file: std::fs::File,
+    dir: PathBuf,
+    sent: u64,
 }
 
-fn write_log_offset(dir: &Path, offset: u64) {
-    let _ = std::fs::write(dir.join("log.offset"), offset.to_string());
+impl LogCursor {
+    /// Open build.log at the persisted offset. A missing file means
+    /// the build never started a builder, so there is no cursor.
+    fn open(dir: &Path) -> Option<Self> {
+        use std::io::Seek;
+        let mut file = std::fs::File::open(dir.join("build.log")).ok()?;
+        let sent = std::fs::read_to_string(dir.join("log.offset"))
+            .ok()
+            .and_then(|s| s.trim().parse().ok())
+            .unwrap_or(0);
+        file.seek(std::io::SeekFrom::Start(sent)).ok()?;
+        Some(Self {
+            file,
+            dir: dir.to_path_buf(),
+            sent,
+        })
+    }
+
+    /// Read to EOF and persist the offset after every accepted
+    /// chunk. Returns false when `emit` rejects a chunk or the file
+    /// breaks.
+    fn drain(&mut self, mut emit: impl FnMut(Vec<u8>) -> bool) -> bool {
+        let mut buf = [0u8; 8192];
+        loop {
+            match self.file.read(&mut buf) {
+                Ok(0) => return true,
+                Err(_) => return false,
+                Ok(n) => {
+                    if !emit(buf[..n].to_vec()) {
+                        return false;
+                    }
+                    self.sent += n as u64;
+                    let _ = std::fs::write(self.dir.join("log.offset"), self.sent.to_string());
+                }
+            }
+        }
+    }
 }
 
-/// Stream `dir`'s build.log to `out_tx` as LogChunks for `build_id`,
-/// starting at the persisted offset and advancing it after every
-/// chunk handed to the session. Polls past EOF until `done()` says
-/// nothing more can arrive (one final read has then already drained
-/// what was flushed); a failed send ends it, the offset stays put.
+/// Stream `dir`'s build.log to `out_tx` as LogChunks for `build_id`.
+/// Keeps polling past EOF until `done()` reports that nothing more
+/// can arrive.
 pub(super) fn tail_log(
     dir: &Path,
     build_id: &str,
     out_tx: &mpsc::Sender<WorkerMessage>,
     done: impl Fn() -> bool,
 ) {
-    use std::io::Seek;
-    let Ok(mut file) = std::fs::File::open(dir.join("build.log")) else {
+    let Some(mut cursor) = LogCursor::open(dir) else {
         return;
     };
-    let mut sent = read_log_offset(dir);
-    if file.seek(std::io::SeekFrom::Start(sent)).is_err() {
-        return;
-    }
-    let mut buf = [0u8; 8192];
-    loop {
-        match file.read(&mut buf) {
-            Ok(0) => {
-                if done() {
-                    break;
-                }
-                std::thread::sleep(std::time::Duration::from_millis(100));
-            }
-            Err(_) => break,
-            Ok(n) => {
-                if out_tx
-                    .blocking_send(msg(worker_message::Msg::Log(LogChunk {
-                        build_id: build_id.into(),
-                        data: buf[..n].to_vec(),
-                    })))
-                    .is_err()
-                {
-                    break;
-                }
-                sent += n as u64;
-                write_log_offset(dir, sent);
-            }
-        }
+    let mut emit = |data| {
+        out_tx
+            .blocking_send(msg(worker_message::Msg::Log(LogChunk {
+                build_id: build_id.into(),
+                data,
+            })))
+            .is_ok()
+    };
+    while cursor.drain(&mut emit) && !done() {
+        std::thread::sleep(std::time::Duration::from_millis(100));
     }
 }
 
@@ -107,4 +119,47 @@ pub(super) fn spawn_log_tail(
         tail_log(&dir, &build_id, &out_tx, done);
     });
     LogTail { done, handle }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn offset(dir: &Path) -> u64 {
+        std::fs::read_to_string(dir.join("log.offset"))
+            .unwrap()
+            .parse()
+            .unwrap()
+    }
+
+    #[test]
+    fn cursor_resumes_at_persisted_offset() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("build.log"), b"old-new").unwrap();
+        std::fs::write(dir.path().join("log.offset"), "4").unwrap();
+        let mut cursor = LogCursor::open(dir.path()).unwrap();
+        let mut got = Vec::new();
+        assert!(cursor.drain(|d| {
+            got.extend(d);
+            true
+        }));
+        assert_eq!(got, b"new");
+        assert_eq!(offset(dir.path()), 7);
+    }
+
+    #[test]
+    fn rejected_chunk_keeps_offset_for_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("build.log"), b"hello").unwrap();
+        std::fs::write(dir.path().join("log.offset"), "0").unwrap();
+        let mut cursor = LogCursor::open(dir.path()).unwrap();
+        assert!(!cursor.drain(|_| false));
+        assert_eq!(offset(dir.path()), 0);
+    }
+
+    #[test]
+    fn missing_log_means_no_cursor() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(LogCursor::open(dir.path()).is_none());
+    }
 }

--- a/crates/tribuchet/src/worker/logtail.rs
+++ b/crates/tribuchet/src/worker/logtail.rs
@@ -51,6 +51,13 @@ impl LogCursor {
         })
     }
 
+    fn persist_offset(&self) {
+        let tmp = self.dir.join("log.offset.tmp");
+        if std::fs::write(&tmp, self.sent.to_string()).is_ok() {
+            let _ = std::fs::rename(&tmp, self.dir.join("log.offset"));
+        }
+    }
+
     /// Read to EOF and persist the offset after every accepted
     /// chunk. Returns false when `emit` rejects a chunk or the file
     /// breaks.
@@ -65,7 +72,7 @@ impl LogCursor {
                         return false;
                     }
                     self.sent += n as u64;
-                    let _ = std::fs::write(self.dir.join("log.offset"), self.sent.to_string());
+                    self.persist_offset();
                 }
             }
         }

--- a/crates/tribuchet/src/worker/resume.rs
+++ b/crates/tribuchet/src/worker/resume.rs
@@ -12,7 +12,7 @@ use harmonia_utils_signature::SecretKey;
 use tokio::sync::mpsc;
 
 use super::build::ActiveBuild;
-use super::build::{LogMirror, supervise_agent};
+use super::build::supervise_agent;
 use super::logtail::LogTail;
 use super::{DaemonConn, WorkerCtx, msg, sandbox};
 use crate::chunkio::CHUNK_SIZE;
@@ -91,13 +91,7 @@ pub(super) async fn adopt_builds(ctx: &Arc<WorkerCtx>, signing_key: &Arc<SecretK
             let key = st.dedupe_key.clone();
             let fin = {
                 let (socket, build) = agent;
-                // Keep mirroring the agent-side log into dir/build.log
-                // so replay and abort heuristics see fresh data.
-                let mirror = LogMirror::start(&build.log, dir.join("build.log")).ok();
                 let fin = supervise_agent(&ctx, &st, dir, &socket, build, &signing_key);
-                if let Some(m) = mirror {
-                    m.stop();
-                }
                 ctx.agents.release(socket);
                 fin
             };

--- a/nix/darwin-module.nix
+++ b/nix/darwin-module.nix
@@ -32,7 +32,7 @@ let
   attachDir = lib.escapeShellArg (dirOf (toString hub.socketPath));
   agentUser = i: "_tribuchetbld${toString i}";
   agentSocket = i: "/var/run/tribuchet/agents/${toString i}.sock";
-  agentStateDir = i: "/var/lib/tribuchet-agents/${toString i}";
+  agentStateDir = i: "/var/lib/tribuchet/a${toString i}";
   # nixbld gid: build users must be able to create their outputs in
   # the group-writable /nix/store.
   nixbldGid = 350;
@@ -74,7 +74,7 @@ in
     };
     socketPath = lib.mkOption {
       type = lib.types.path;
-      default = "/var/lib/tribuchet-hub/attach.sock";
+      default = "/var/lib/tribuchet/hub/attach.sock";
       description = ''
         Unix socket `tribuchet attach` (Nix's external builder)
         connects to. Its directory is made root:nixbld 0750 at
@@ -108,7 +108,7 @@ in
     };
     stateDir = lib.mkOption {
       type = lib.types.path;
-      default = "/var/lib/tribuchet";
+      default = "/var/lib/tribuchet/worker";
       description = "State directory: TLS material, build dirs, exec symlink.";
     };
     agents = lib.mkOption {

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -30,7 +30,7 @@ let
     i:
     pkgs.writeShellScript "tribuchet-agent-${toString i}" ''
       exec ${lib.getExe' worker.package "tribuchet"} agent \
-        --state-dir /var/lib/${agentUser i} \
+        --state-dir /var/lib/tribuchet/a${toString i} \
         --uid-base ${toString (worker.agentUidBase + (i - 1) * 65536)} \
         --worker-uid "$(${lib.getExe' pkgs.coreutils "id"} -u tribuchet)"
     '';
@@ -370,7 +370,7 @@ in
             ExecStart = agentStart i;
             User = agentUser i;
             Group = agentUser i;
-            StateDirectory = agentUser i;
+            StateDirectory = "tribuchet/a${toString i}";
             # Traverse-only for the worker and the uid block: the
             # per-build scratch dirs under it are world-writable for
             # the block, but their names are unguessable build ids and
@@ -416,7 +416,7 @@ in
               ExecStart = "${lib.getExe' worker.package "tribuchet"} worker --config /etc/tribuchet/worker.toml";
               # Running builds live in the agent services and are
               # re-adopted by the next worker instance.
-              StateDirectory = "tribuchet";
+              StateDirectory = "tribuchet/worker";
               Environment = [
                 "RUST_LOG=info"
               ]

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -270,7 +270,7 @@ in
         for f in ["worker.crt", "worker.key", "ca.crt"]:
             pem = hub.succeed(f"cat /root/ca/{f}")
             worker.succeed(f"cat > /var/lib/tribuchet/tls/{f} << 'PEMEOF'\n{pem}PEMEOF")
-        worker.succeed("chown -R tribuchet:tribuchet /var/lib/tribuchet")
+        worker.succeed("chown -R tribuchet:tribuchet /var/lib/tribuchet/tls")
 
     with subtest("worker registers at hub over mTLS"):
         hub.succeed("systemctl start tribuchet-hub.socket")

--- a/nix/worker-image.nix
+++ b/nix/worker-image.nix
@@ -36,7 +36,7 @@ dockerTools.buildLayeredImage {
     nixConf
   ];
   extraCommands = ''
-    mkdir -p tmp var/lib/tribuchet etc/tribuchet nix/var/nix
+    mkdir -p tmp var/lib/tribuchet/worker etc/tribuchet nix/var/nix
   '';
   config = {
     Entrypoint = [ entrypoint ];


### PR DESCRIPTION

Whole build logs went missing when the tailer thread started before
LogMirror's thread created dir/build.log: the tailer exited silently
and nix logs showed nothing but the dispatch line.

Remove the mirror instead of patching the race. The worker creates
builds/<id>/build.log up front and passes a write fd in the Start
call, so the builder writes the one file that tailing, replay, resume
and the abort heuristics already read.

Start now carries the log fd and the replies no longer return one, so
workers and agents must be updated together.
