### PR TITLE
nix: derive agent pool from max-jobs instead of an agents option

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ Import `tribuchet.nixosModules.default` (flake input
     enable = true;
     settings = {
       hub = "https://hub.example.org:7437";
-      max-jobs = 4;
+      # Concurrent builds. Defaults to the core count at runtime, up
+      # to 64 (32 on darwin). Set explicitly to go beyond or below.
+      # max-jobs = 128;
     };
   };
 }

--- a/nix/darwin-module.nix
+++ b/nix/darwin-module.nix
@@ -26,7 +26,11 @@ let
   execLink = "${cfg.stateDir}/exec";
   label = "org.nixos.tribuchet-worker";
   format = pkgs.formats.toml { };
-  agentIds = lib.range 1 cfg.agents;
+  # One per-uid build agent per concurrent build. With max-jobs unset
+  # the worker uses min(cores, agents). Smaller ceiling than Linux
+  # since each agent needs a hidden user account.
+  agentCount = cfg.settings.max-jobs or 32;
+  agentIds = lib.range 1 agentCount;
   # launchd cannot set a socket group and the rootless hub cannot
   # chown the socket, so this directory carries the nixbld restriction.
   attachDir = lib.escapeShellArg (dirOf (toString hub.socketPath));
@@ -40,7 +44,6 @@ let
     {
       state-dir = toString cfg.stateDir;
       agent-sockets = map agentSocket agentIds;
-      max-jobs = cfg.agents;
     }
     // cfg.settings
   );
@@ -110,15 +113,6 @@ in
       type = lib.types.path;
       default = "/var/lib/tribuchet/worker";
       description = "State directory: TLS material, build dirs, exec symlink.";
-    };
-    agents = lib.mkOption {
-      type = lib.types.ints.positive;
-      default = 4;
-      description = ''
-        Number of per-uid build agents. Bounds concurrent builds and
-        sets the worker's max-jobs (overridable via `settings`, but
-        never above the agent count).
-      '';
     };
     uid = lib.mkOption {
       type = lib.types.int;

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -20,7 +20,11 @@ let
   worker = config.services.tribuchet-worker;
   defaultPackage = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
   format = pkgs.formats.toml { };
-  agentIds = lib.range 1 worker.agents;
+  # One per-uid build agent per concurrent build. With max-jobs unset
+  # the worker uses min(cores, agents), so provision a generous
+  # ceiling. Idle agents are socket-activated and cost nothing.
+  agentCount = worker.settings.max-jobs or 64;
+  agentIds = lib.range 1 agentCount;
   agentUser = i: "tribuchet-agent-${toString i}";
   forEachAgent = f: lib.listToAttrs (map (i: lib.nameValuePair (agentUser i) (f i)) agentIds);
   agentSocket = i: "/run/tribuchet/agents/${toString i}.sock";
@@ -45,7 +49,6 @@ let
   workerToml = format.generate "worker.toml" (
     {
       agent-sockets = map agentSocket agentIds;
-      max-jobs = worker.agents;
     }
     // worker.settings
   );
@@ -185,15 +188,6 @@ in
         LoadCredential so it may stay root-owned (e.g. a sops secret).
         Passed to the worker via TRIBUCHET_KEY; leave `settings.key`
         unset when using this.
-      '';
-    };
-    agents = lib.mkOption {
-      type = lib.types.ints.positive;
-      default = 4;
-      description = ''
-        Number of per-uid build agents. Bounds concurrent builds and
-        sets the worker's max-jobs (overridable via `settings`, but
-        never above the agent count).
       '';
     };
     agentUidBase = lib.mkOption {


### PR DESCRIPTION
Exposing both an agents option and the worker's max-jobs setting was confusing: they bound the same thing. Drop the option and size the per-uid agent pool from settings.max-jobs directly. When unset, the worker already defaults max-jobs to the host's core count clamped to the agent count, so the modules provision a generous ceiling (64 agents on NixOS, 32 on darwin where each agent needs a real user account) and concurrency self-tunes to min(cores, ceiling) at runtime. Idle agents are socket-activated and effectively free.