### PR TITLE
worker: silence Darwin dead-code warnings for Linux-only items

### DIFF
--- a/crates/tribuchet/src/config.rs
+++ b/crates/tribuchet/src/config.rs
@@ -204,6 +204,7 @@ pub struct WorkerConfig {
     /// and maps the 65536-uid block starting at base+i*65536. Needs a
     /// root worker. If unset, builds share the worker uid.
     #[serde(default)]
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub agent_uid_base: Option<u32>,
 }
 

--- a/crates/tribuchet/src/worker.rs
+++ b/crates/tribuchet/src/worker.rs
@@ -60,6 +60,7 @@ type DaemonConn = DaemonClient<tokio::net::unix::OwnedReadHalf, tokio::net::unix
 /// Per-process context threaded through builds.
 struct WorkerCtx {
     state_dir: PathBuf,
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     sandbox_bin_sh: Option<PathBuf>,
     /// Files a build must never read even where DAC would allow it
     /// (macOS Seatbelt deny rules; Linux relies on the mount namespace).
@@ -74,8 +75,10 @@ struct WorkerCtx {
     emulators: HashMap<String, PathBuf>,
     /// Fixed-output builds get a private netns with the presto-pasta
     /// user-mode NAT (Linux workers with /dev/net/tun).
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     fod_isolation: bool,
     /// Flow policy for that network, from the fod-network setting.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     fod_network: crate::netpolicy::NetPolicy,
     max_silent_time: Duration,
     max_log_size: u64,

--- a/crates/tribuchet/src/worker/agent.rs
+++ b/crates/tribuchet/src/worker/agent.rs
@@ -113,6 +113,7 @@ pub struct Options {
     pub worker_uid: Option<u32>,
     /// First uid of this agent's 65536-uid block (Linux). Without it
     /// builds run without a pre-mapped user namespace.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub uid_base: Option<u32>,
     /// The agent owns its uid even without socket activation, so it
     /// kill-sweeps the uid and exits after each build.

--- a/crates/tribuchet/src/worker/sandbox.rs
+++ b/crates/tribuchet/src/worker/sandbox.rs
@@ -143,18 +143,22 @@ pub struct PrepareOpts<'a> {
 pub enum Error {
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    #[cfg(target_os = "linux")]
     #[error("{step}")]
     Step {
         step: String,
         #[source]
         source: std::io::Error,
     },
+    #[cfg(target_os = "linux")]
     #[error("sending sandbox spec")]
     SendSpec(#[source] serde_json::Error),
+    #[cfg(target_os = "linux")]
     #[error("no binfmt magic known for system {0}")]
     UnknownBinfmt(String),
 }
 
+#[cfg(target_os = "linux")]
 fn step<E: Into<std::io::Error>>(step: impl Into<String>) -> impl FnOnce(E) -> Error {
     |source| Error::Step {
         step: step.into(),


### PR DESCRIPTION

WorkerCtx sandbox fields, the agent uid_base option and the
sandbox Step/SendSpec/UnknownBinfmt error machinery are only
consumed by the Linux sandbox path, so the macOS build flagged
them as never read. Gate the Linux-only error variants behind
cfg(target_os = "linux") and mark the shared struct fields with
cfg_attr(allow(dead_code)) since they must stay for config
parsing and CLI parity across platforms.
