### PR TITLE
worker: agent: recover from stale scratch trees at build start

### DIFF
--- a/crates/tribuchet/src/worker/agent.rs
+++ b/crates/tribuchet/src/worker/agent.rs
@@ -259,7 +259,7 @@ fn handle_start(
         // Short fixed name keeps sandbox socket paths within sun_path.
         let scratch_root = agent.state_dir.join("scratch");
         let build_dir = scratch_root.join("build");
-        let _ = fs::remove_dir_all(&scratch_root);
+        platform::clean_scratch(&agent.confinement, &scratch_root)?;
         fs::create_dir_all(&scratch_root)?;
         platform::stage_tmp_dir(&agent.confinement, &scratch_root, &build_dir, tmp_pack)
             .map_err(|e| Error::StageTmpDir(Box::new(e)))?;

--- a/crates/tribuchet/src/worker/agent/darwin.rs
+++ b/crates/tribuchet/src/worker/agent/darwin.rs
@@ -59,6 +59,15 @@ pub(super) fn finish(_confinement: &Confinement, _root: Option<&Path>, outputs: 
     }
 }
 
+/// Remove a stale scratch tree before a new build. The agent's own
+/// uid owns everything, so a plain removal suffices.
+pub(super) fn clean_scratch(_confinement: &Confinement, scratch_root: &Path) -> Result<(), Error> {
+    match fs::remove_dir_all(scratch_root) {
+        Err(e) if e.kind() != std::io::ErrorKind::NotFound => Err(e.into()),
+        _ => Ok(()),
+    }
+}
+
 /// Remove the build's scratch tree and its store-path outputs; the
 /// sticky store dir lets the owning agent delete them.
 pub(super) fn cleanup(_confinement: &Confinement, build: &super::Build) {

--- a/crates/tribuchet/src/worker/agent/linux.rs
+++ b/crates/tribuchet/src/worker/agent/linux.rs
@@ -241,6 +241,33 @@ pub(super) fn finish(confinement: &Confinement, root: Option<&Path>, outputs: &[
     }
 }
 
+/// Remove a stale scratch tree before a new build. Uid-block files
+/// need the userns helper, the agent-owned remainder a plain pass.
+/// Agent-owned entries never nest under uid-block ones, so one pass
+/// of each suffices.
+pub(super) fn clean_scratch(confinement: &Confinement, scratch_root: &Path) -> Result<(), Error> {
+    match fs::remove_dir_all(scratch_root) {
+        Ok(()) => return Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(_) if confinement.userns.is_some() => {
+            run_in_userns(
+                confinement,
+                "remove",
+                std::slice::from_ref(&scratch_root.to_path_buf()),
+            )?;
+        }
+        Err(e) => return Err(e.into()),
+    }
+    match fs::remove_dir_all(scratch_root) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(msg(format!(
+            "stale scratch tree {} could not be removed: {e}",
+            scratch_root.display()
+        ))),
+    }
+}
+
 /// Remove a build's cgroup and scratch tree, plus stray outputs. A
 /// namespace build's tree contains uid-block files only deletable
 /// inside the userns; its outputs live under that tree.

--- a/crates/tribuchet/src/worker/sandbox/linux.rs
+++ b/crates/tribuchet/src/worker/sandbox/linux.rs
@@ -48,16 +48,16 @@ const TUNSETIFF: Opcode = opcode::write::<libc::c_int>(b'T', 202);
 // linux/sockios.h
 const SIOCSIFFLAGS: Opcode = 0x8914;
 
-/// Create the sandbox root skeleton (directories, /etc files, /dev
-/// nodes) for a spec whose scratch paths the caller filled in. Runs on
-/// the worker for its own builds and in the build agent for leased
-/// ones.
 use super::{Error, step};
 
+/// Prepare the on-disk sandbox root and finalize the spec. Only the
+/// scratch store is created on disk because outputs must survive the
+/// namespace. The rest of the root lives on the in-namespace tmpfs,
+/// so nothing stale persists across builds.
 pub fn prepare_root(spec: &mut SandboxSpec) -> Result<(), Error> {
     let root = &spec.root;
-    write_skeleton(spec)?;
-    populate_dev(root, &mut spec.binds_dev)?;
+    fs::create_dir_all(root.join("nix/store"))?;
+    dev_binds(&mut spec.binds_dev);
     if spec.network {
         // Host CA bundle at the standard path for TLS fetches, like
         // Nix's fixed-output setup.
@@ -78,9 +78,8 @@ pub fn prepare_root(spec: &mut SandboxSpec) -> Result<(), Error> {
     Ok(())
 }
 
-/// Sandbox root skeleton: directories, /etc files, /dev symlinks. Runs
-/// on the on-disk root in the worker and again on a leased build's
-/// in-namespace tmpfs root.
+/// Sandbox root skeleton: directories, /etc files, /dev symlinks.
+/// Runs only on the build's in-namespace tmpfs root.
 fn write_skeleton(spec: &SandboxSpec) -> Result<(), Error> {
     let root = &spec.root;
     for sub in [
@@ -146,8 +145,8 @@ fn write_skeleton(spec: &SandboxSpec) -> Result<(), Error> {
 }
 
 /// Mount points for the cwd, bind targets and symlinked store inputs
-/// inside the sandbox root. Like `write_skeleton`, runs in the worker
-/// and again on a leased build's tmpfs root.
+/// inside the sandbox root. Like `write_skeleton`, runs only on the
+/// tmpfs root.
 fn create_mount_points(spec: &SandboxSpec) -> Result<(), Error> {
     // The shipped tmp dir is mounted at the request's sandbox build
     // dir; pre-create the mount point inside the private root.
@@ -194,7 +193,7 @@ fn create_mount_points(spec: &SandboxSpec) -> Result<(), Error> {
 /// copies (impossible in a leased user namespace anyway). The mounts
 /// are read-only, so a sandbox mapping a host uid that owns a node
 /// cannot chmod/chown it; device I/O is unaffected by MS_RDONLY.
-fn populate_dev(root: &Path, binds_dev: &mut Vec<(PathBuf, PathBuf)>) -> Result<(), Error> {
+fn dev_binds(binds_dev: &mut Vec<(PathBuf, PathBuf)>) {
     let mut devices = vec!["null", "zero", "full", "random", "urandom", "tty"];
     // Nix's `kvm` system feature (VM builds, NixOS tests).
     if Path::new("/dev/kvm").exists() {
@@ -202,15 +201,11 @@ fn populate_dev(root: &Path, binds_dev: &mut Vec<(PathBuf, PathBuf)>) -> Result<
     }
     for dev in devices {
         let host = PathBuf::from("/dev").join(dev);
-        fs::File::create(root.join("dev").join(dev))?;
         binds_dev.push((host.clone(), host));
     }
-    Ok(())
 }
 
 pub fn command(spec: &SandboxSpec) -> Result<Command, Error> {
-    create_mount_points(spec)?;
-
     if spec.emulator.is_some() && binfmt::register_line(&spec.system).is_none() {
         return Err(Error::UnknownBinfmt(spec.system.clone()));
     }
@@ -701,7 +696,6 @@ fn tmpfs_root(p: &SetupParams) -> io::Result<()> {
     mount("tmpfs", root, "tmpfs", MountFlags::empty(), None)
         .map_err(ioerr("mounting tmpfs root"))?;
     write_skeleton(p.spec)
-        .and_then(|()| create_mount_points(p.spec))
         .map_err(|e| io::Error::other(format!("populating tmpfs root: {e:#}")))?;
     move_mount(
         store.as_fd(),
@@ -710,7 +704,10 @@ fn tmpfs_root(p: &SetupParams) -> io::Result<()> {
         root.join("nix/store"),
         MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH,
     )
-    .map_err(ioerr("attaching scratch store"))
+    .map_err(ioerr("attaching scratch store"))?;
+    // After the store reattach, so store-input mount points land on
+    // the on-disk store instead of being hidden by it.
+    create_mount_points(p.spec).map_err(|e| io::Error::other(format!("mount points: {e:#}")))
 }
 
 /// Fresh per-userns binfmt_misc instance (kernel 6.7+) so emulated


### PR DESCRIPTION

When an agent dies mid-build, cleanup never runs and the next Start's
remove_dir_all silently fails on uid-block files. Stale /dev symlinks
then break write_skeleton with EEXIST for every later build.

Keep only nix/store on disk (the tmpfs root recreates the rest) and
clean stale trees via the userns helper, failing loudly.
