### PR TITLE
flakelet modules for hub and worker

### DIFF
--- a/crates/tribuchet/src/config.rs
+++ b/crates/tribuchet/src/config.rs
@@ -227,6 +227,10 @@ pub struct WorkerConfig {
     /// agent count bounds concurrent builds.
     #[serde(default)]
     pub agent_sockets: Vec<PathBuf>,
+    /// Directory whose `*.sock` entries are appended to agent-sockets at
+    /// startup, for hosts that size the agent count at boot.
+    #[serde(default)]
+    pub agent_sockets_dir: Option<PathBuf>,
     /// Number of agents the worker spawns and supervises itself, for
     /// hosts without systemd-managed agent units such as containers.
     /// Mutually exclusive with agent-sockets.

--- a/crates/tribuchet/src/main.rs
+++ b/crates/tribuchet/src/main.rs
@@ -21,10 +21,15 @@ mod worker;
 
 #[cfg(target_os = "linux")]
 use std::env;
+use std::fs;
+use std::num::NonZero;
+use std::os::unix::fs::symlink;
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::thread;
 
 use clap::{Parser, Subcommand};
+use errors::{Error, err_ctx, err_msg};
 
 /// RBE-style remote build execution for Nix, driven by the
 /// `external-builders` experimental feature.
@@ -83,6 +88,20 @@ enum Command {
         #[arg(long)]
         dedicated_uid: bool,
     },
+    /// systemd generator: want one agent socket per CPU.
+    AgentGenerator {
+        /// Unit the sockets are ordered before and wanted by, e.g. tribuchet-worker.service.
+        #[arg(long)]
+        worker_unit: String,
+        /// Socket template, e.g. tribuchet-agent@.socket.
+        #[arg(long)]
+        template: String,
+        /// Upper bound on the count.
+        #[arg(long)]
+        max: Option<usize>,
+        /// normal, early and late output directories passed by systemd.
+        dirs: Vec<PathBuf>,
+    },
 }
 
 fn main() -> ExitCode {
@@ -95,7 +114,7 @@ fn main() -> ExitCode {
     }
 }
 
-fn run() -> Result<(), errors::Error> {
+fn run() -> Result<(), Error> {
     // Builds re-exec this binary as the sandbox setup stage; divert
     // before clap and tracing touch anything.
     #[cfg(target_os = "linux")]
@@ -147,5 +166,42 @@ fn run() -> Result<(), errors::Error> {
             uid_base,
             dedicated_uid,
         })?),
+        Command::AgentGenerator {
+            worker_unit,
+            template,
+            max,
+            dirs,
+        } => agent_generator(&worker_unit, &template, max, &dirs),
     }
+}
+
+fn agent_generator(
+    worker_unit: &str,
+    template: &str,
+    max: Option<usize>,
+    dirs: &[PathBuf],
+) -> Result<(), Error> {
+    let out = dirs
+        .first()
+        .ok_or_else(|| err_msg("systemd passes the output directory"))?;
+    let (prefix, suffix) = template
+        .split_once("@.")
+        .ok_or_else(|| err_msg("template must look like name@.socket"))?;
+    let mut n = thread::available_parallelism().map_or(1, NonZero::get);
+    if let Some(max) = max {
+        n = n.min(max);
+    }
+    for wants in [
+        "sockets.target.wants".to_string(),
+        format!("{worker_unit}.wants"),
+    ] {
+        let dir = out.join(wants);
+        fs::create_dir_all(&dir).map_err(err_ctx(format!("mkdir {}", dir.display())))?;
+        for i in 1..=n {
+            let link = dir.join(format!("{prefix}@{i}.{suffix}"));
+            symlink(format!("../{template}"), &link)
+                .map_err(err_ctx(format!("symlink {}", link.display())))?;
+        }
+    }
+    Ok(())
 }

--- a/crates/tribuchet/src/worker.rs
+++ b/crates/tribuchet/src/worker.rs
@@ -328,6 +328,16 @@ async fn run_async(opts: WorkerConfig) -> Result<()> {
                 agent_spawn::spawn(&opts.state_dir, opts.spawn_agents, opts.agent_uid_base)?;
         }
     }
+    if let Some(dir) = &opts.agent_sockets_dir {
+        let mut found: Vec<PathBuf> = fs::read_dir(dir)
+            .map_err(|e| err_msg(format!("agent-sockets-dir {}: {e}", dir.display())))?
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|x| x == "sock"))
+            .collect();
+        found.sort();
+        opts.agent_sockets.extend(found);
+    }
     // Every build runs on one agent, so the agent list bounds
     // concurrency.
     if opts.agent_sockets.is_empty() {

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,13 @@
 
       nixosModules.default = import ./nix/nixos-module.nix self;
 
+      # Run hub/worker via flakelet (https://github.com/Mic92/flakelet):
+      # units update from this flake independently of the host system.
+      flakelets = {
+        hub = import ./nix/flakelet-hub.nix { inherit crane; };
+        worker = import ./nix/flakelet-worker.nix { inherit crane; };
+      };
+
       # CI builds every package and devShell on every system, plus the
       # x86_64-linux-only checks below.
       checks = forAllSystems (

--- a/nix/flakelet-hub.nix
+++ b/nix/flakelet-hub.nix
@@ -1,0 +1,128 @@
+# flakelet module for the hub (https://github.com/Mic92/flakelet).
+# Ships only the units. Firewall and externalBuilders stay host
+# configuration (services.tribuchet-hub.* without `enable`).
+{ crane }:
+{ types, ... }:
+{
+  options = {
+    listenAddress = {
+      type = types.string;
+      default = "0.0.0.0";
+      description = "Address of the worker-facing gRPC listener.";
+    };
+    port = {
+      type = types.int;
+      default = 7437;
+      description = "Port of the worker-facing gRPC listener.";
+    };
+    socketPath = {
+      type = types.string;
+      defaultFunc = { inputs, ... }: "/run/${inputs.flakelet.name}/hub.sock";
+      description = "Attach socket path.";
+    };
+    socketGroup = {
+      type = types.string;
+      default = "nixbld";
+      description = "Group allowed to connect to the attach socket.";
+    };
+    configDir = {
+      type = types.string;
+      default = "/etc/tribuchet";
+      description = "Directory with the CA material and hub TLS key pair.";
+    };
+    nixConfigPath = {
+      type = types.option types.string;
+      description = "Enable dynamic external-builders: path of the hub-written nix.conf fragment.";
+    };
+    oversubscribePercent = {
+      type = types.int;
+      default = 200;
+    };
+    maxJobsCap = {
+      type = types.int;
+      default = 256;
+    };
+    hub = {
+      type = types.attrsOf types.any;
+      default = { };
+      description = "Extra hub.toml settings, merged verbatim.";
+    };
+  };
+
+  impl =
+    { options, inputs }:
+    let
+      inherit (inputs.nixpkgs) pkgs lib;
+      inherit (inputs.flakelet) name;
+      # Built against the host's nixpkgs like every flakelet; crane is a
+      # pure library and brings no nixpkgs of its own.
+      package = pkgs.callPackage ./package.nix { craneLib = crane.mkLib pkgs; };
+      format = pkgs.formats.toml { };
+      inherit (options)
+        listenAddress
+        port
+        configDir
+        socketPath
+        ;
+      attachWrapper = pkgs.writeShellScript "tribuchet-attach" ''
+        exec ${lib.getExe' package "tribuchet"} attach "$1" --socket ${socketPath}
+      '';
+      hubToml = format.generate "hub.toml" (
+        {
+          socket = socketPath;
+          listen = "${listenAddress}:${toString port}";
+          config-dir = configDir;
+        }
+        # Dynamic external-builders: the hub rewrites the host's nix.conf
+        # fragment as workers come and go. The attach program lives in this
+        # flakelet's closure, so generations keep it gc-rooted.
+        // lib.optionalAttrs (options.nixConfigPath != null) {
+          nix-config = {
+            path = options.nixConfigPath;
+            attach-program = toString attachWrapper;
+            oversubscribe-percent = options.oversubscribePercent;
+            max-jobs-cap = options.maxJobsCap;
+          };
+        }
+        // options.hub
+      );
+    in
+    {
+      sockets.${name} = {
+        description = "tribuchet hub sockets";
+        wantedBy = [ "sockets.target" ];
+        socketConfig = {
+          ListenStream = [
+            socketPath
+            "${listenAddress}:${toString port}"
+          ];
+          SocketGroup = options.socketGroup;
+          SocketMode = "0660";
+          # Owned by the socket unit so a service stop keeps the path.
+          RuntimeDirectory = name;
+        };
+      };
+
+      services.${name} = {
+        description = "tribuchet build hub";
+        wantedBy = [ "multi-user.target" ];
+        requires = [ "${name}.socket" ];
+        after = [ "${name}.socket" ];
+        serviceConfig = {
+          Type = "notify";
+          ExecStart = "${lib.getExe' package "tribuchet"} hub --config ${hubToml}";
+          RuntimeDirectory = name;
+          RuntimeDirectoryPreserve = true;
+          CacheDirectory = name;
+          Environment = [
+            "RUST_LOG=info"
+            "XDG_CACHE_HOME=/var/cache/${name}"
+          ];
+          WatchdogSec = "30";
+          Restart = "on-failure";
+        };
+      };
+
+      exports.ports.workers = { inherit port; };
+    };
+}

--- a/nix/flakelet-worker.nix
+++ b/nix/flakelet-worker.nix
@@ -1,0 +1,58 @@
+# flakelet module for the worker and its build agents, see
+# nix/worker-units.nix. The host only has to add tribuchet to
+# nix.settings.trusted-users.
+{ crane }:
+{ types, ... }:
+{
+  options = {
+    agents = {
+      type = types.union [
+        types.int
+        (types.enum "auto" [ "auto" ])
+      ];
+      default = "auto";
+      description = "Build agent count, or \"auto\" for one per CPU, decided on the machine.";
+    };
+    agentUidBase = {
+      type = types.int;
+      default = 1325400064;
+      description = "First uid of the agents' 65536-uid blocks.";
+    };
+    keyFile = {
+      type = types.option types.string;
+      description = "TLS client key for the hub connection, loaded via LoadCredential.";
+    };
+    worker = {
+      type = types.attrsOf types.any;
+      description = "Contents of worker.toml; the hub key is required.";
+    };
+  };
+
+  impl =
+    { options, inputs }:
+    let
+      inherit (inputs.nixpkgs) pkgs lib;
+      inherit (inputs.flakelet) name;
+      units = import ./worker-units.nix {
+        inherit pkgs lib;
+        package = pkgs.callPackage ./package.nix { craneLib = crane.mkLib pkgs; };
+        workerUnit = name;
+        agentUnit = "${name}-agent@";
+        inherit (options) agents agentUidBase keyFile;
+        workerToml = (pkgs.formats.toml { }).generate "worker.toml" (
+          {
+            agent-sockets-dir = units.agentSocketsDir;
+          }
+          // options.worker
+        );
+      };
+    in
+    {
+      inherit (units) generators;
+      sockets."agent@" = units.agentSocketConfig // {
+        instances = units.agentInstances;
+      };
+      services."agent@" = units.agentServiceConfig;
+      services.${name} = units.workerServiceConfig;
+    };
+}

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -2,12 +2,7 @@
 #
 # Hub: socket-activated (systemd holds the attach socket and the worker
 # port), so hub restarts never refuse connections, clients just queue.
-# Worker: runs unprivileged as tribuchet and leases every build to a
-# per-uid agent (tribuchet-agent-N, socket-activated), which owns the
-# builder process and its user namespace, so builds survive worker
-# stops and restarts. A restarted worker re-adopts them from the
-# state persisted in its build dirs, so package upgrades and settings
-# changes are plain restarts.
+# Worker and agents: see worker-units.nix.
 self:
 {
   config,
@@ -20,23 +15,18 @@ let
   worker = config.services.tribuchet-worker;
   defaultPackage = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
   format = pkgs.formats.toml { };
-  # One per-uid build agent per concurrent build. With max-jobs unset
-  # the worker uses min(cores, agents), so provision a generous
-  # ceiling. Idle agents are socket-activated and cost nothing.
-  agentCount = worker.settings.max-jobs or 64;
-  agentIds = lib.range 1 agentCount;
-  agentUser = i: "tribuchet-agent-${toString i}";
-  agentInstance = i: "tribuchet-agent@${toString i}";
-  forEachAgent = f: lib.listToAttrs (map (i: lib.nameValuePair (agentUser i) (f i)) agentIds);
-  agentSocket = i: "/run/tribuchet/agents/${toString i}.sock";
-  # ExecStart cannot resolve the worker's uid, which the agent needs
-  # for its peer-uid check. Takes the instance number as $1.
-  agentStart = pkgs.writeShellScript "tribuchet-agent" ''
-    exec ${lib.getExe' worker.package "tribuchet"} agent \
-      --state-dir "/var/lib/tribuchet/a$1" \
-      --uid-base "$(( ${toString worker.agentUidBase} + ($1 - 1) * 65536 ))" \
-      --worker-uid "$(${lib.getExe' pkgs.coreutils "id"} -u tribuchet)"
-  '';
+  workerUnits = import ./worker-units.nix {
+    inherit pkgs lib;
+    inherit (worker)
+      package
+      agents
+      agentUidBase
+      keyFile
+      ;
+    workerUnit = "tribuchet-worker";
+    agentUnit = "tribuchet-agent@";
+    workerToml = "/etc/tribuchet/worker.toml";
+  };
   hubToml = format.generate "hub.toml" (
     {
       socket = toString hub.socketPath;
@@ -47,7 +37,7 @@ let
   );
   workerToml = format.generate "worker.toml" (
     {
-      agent-sockets = map agentSocket agentIds;
+      agent-sockets-dir = workerUnits.agentSocketsDir;
     }
     // worker.settings
   );
@@ -189,6 +179,11 @@ in
         unset when using this.
       '';
     };
+    agents = lib.mkOption {
+      type = lib.types.either lib.types.ints.positive (lib.types.enum [ "auto" ]);
+      default = "auto";
+      description = "Build agent count, or \"auto\" for one per CPU, decided at boot.";
+    };
     agentUidBase = lib.mkOption {
       type = lib.types.int;
       default = 1325400064;
@@ -234,7 +229,8 @@ in
   };
 
   config = lib.mkMerge [
-    (lib.mkIf (hub.enable && hub.externalBuilders.enable) {
+    # independent of `enable` so the hub can run as a flakelet
+    (lib.mkIf hub.externalBuilders.enable {
       nix.package =
         let
           patches =
@@ -262,7 +258,7 @@ in
       };
     })
 
-    (lib.mkIf (hub.enable && hub.externalBuilders.enable && hub.externalBuilders.dynamic) {
+    (lib.mkIf (hub.externalBuilders.enable && hub.externalBuilders.dynamic) {
       # The hub owns external-builders/max-jobs; nix.conf just includes
       # its fragment (soft include: nix still starts if it is absent).
       nix.extraOptions = "!include ${hub.externalBuilders.nixConfigPath}\n";
@@ -286,8 +282,11 @@ in
       };
     })
 
-    (lib.mkIf hub.enable {
+    {
       networking.firewall.allowedTCPPorts = lib.optional hub.openFirewall hub.port;
+    }
+
+    (lib.mkIf hub.enable {
       systemd.sockets.tribuchet-hub = {
         wantedBy = [ "sockets.target" ];
         listenStreams = [
@@ -329,116 +328,27 @@ in
       # signatures, which only trusted users may do
       nix.settings.trusted-users = [ "tribuchet" ];
 
-      # One build user per agent. Builds run as (or map) that agent's
-      # uid, never the worker's, so a running build can neither tamper
-      # with the worker nor leave files it cannot delete.
-      users.users = {
-        tribuchet = {
-          isSystemUser = true;
-          group = "tribuchet";
-        };
-      }
-      // forEachAgent (i: {
-        isSystemUser = true;
-        group = agentUser i;
-      });
-      users.groups = {
-        tribuchet = { };
-      }
-      // forEachAgent (_: { });
+      systemd.generators = lib.mapAttrs' (
+        n: v: lib.nameValuePair "tribuchet-${n}" v
+      ) workerUnits.generators;
 
-      # One socket-activated agent per build user. systemd owns the
-      # socket, the agent starts on the first connection and exits
-      # after each build's Cleanup. The socket mode is open because
-      # the agent itself only accepts connections from the worker uid.
       systemd.sockets = {
-        "tribuchet-agent@" = {
-          listenStreams = [ "/run/tribuchet/agents/%i.sock" ];
-          socketConfig.SocketMode = "0666";
-        };
+        "tribuchet-agent@" = removeAttrs workerUnits.agentSocketConfig [ "wantedBy" ];
       }
       // lib.listToAttrs (
         map (
           i:
-          lib.nameValuePair (agentInstance i) {
+          lib.nameValuePair "tribuchet-agent@${i}" {
             overrideStrategy = "asDropin";
             wantedBy = [ "sockets.target" ];
           }
-        ) agentIds
+        ) workerUnits.agentInstances
       );
 
       systemd.services = {
-        "tribuchet-agent@" = {
-          # Exiting after every build is the agent's normal lifecycle,
-          # not a crash loop.
-          unitConfig.StartLimitIntervalSec = 0;
-          # The agent lives for one build and is socket-activated per
-          # lease, so not restarting it here is a graceful drain: the
-          # next lease runs the new ExecStart.
-          restartIfChanged = false;
-          serviceConfig = {
-            ExecStart = "${agentStart} %i";
-            User = "tribuchet-agent-%i";
-            Group = "tribuchet-agent-%i";
-            StateDirectory = "tribuchet/a%i";
-            # Traverse-only for the worker and the uid block: the
-            # per-build scratch dirs under scratch/ are world-writable
-            # for the block, but their names are random and the missing
-            # read bit hides them.
-            StateDirectoryMode = "0711";
-            # Writing the uid/gid maps of the agent's pre-mapped user
-            # namespace needs CAP_SETUID/CAP_SETGID over the uid block;
-            # the agent drops both right after the write. CAP_CHOWN
-            # stays: each build cgroup is handed to its mapped root uid.
-            AmbientCapabilities = [
-              "CAP_SETUID"
-              "CAP_SETGID"
-              "CAP_CHOWN"
-            ];
-            CapabilityBoundingSet = [
-              "CAP_SETUID"
-              "CAP_SETGID"
-              "CAP_CHOWN"
-            ];
-            # delegate the cgroup subtree so the agent can create the
-            # per-build cgroup the sandbox roots its cgroup namespace in
-            Delegate = true;
-            # Builders inherit this; match nix-daemon so they are not
-            # stuck at the systemd default soft limit of 1024 and fail
-            # with EMFILE.
-            LimitNOFILE = 1048576;
-            Environment = "RUST_LOG=info";
-          };
-        };
-        tribuchet-worker = {
-          wantedBy = [ "multi-user.target" ];
-          # the agent sockets must exist before the worker leases builds
-          wants = map (i: "${agentInstance i}.socket") agentIds;
-          after = map (i: "${agentInstance i}.socket") agentIds;
+        "tribuchet-agent@" = workerUnits.agentServiceConfig;
+        tribuchet-worker = workerUnits.workerServiceConfig // {
           restartTriggers = [ workerToml ];
-          serviceConfig = {
-            Type = "notify";
-            LoadCredential = lib.optional (worker.keyFile != null) "worker-key:${worker.keyFile}";
-            User = "tribuchet";
-            Group = "tribuchet";
-            WatchdogSec = "30";
-            ExecStart = "${lib.getExe' worker.package "tribuchet"} worker --config /etc/tribuchet/worker.toml";
-            # Running builds live in the agent services and are
-            # re-adopted by the next worker instance.
-            StateDirectory = "tribuchet/worker";
-            Environment = [
-              "RUST_LOG=info"
-            ]
-            ++ lib.optional (worker.keyFile != null) "TRIBUCHET_KEY=%d/worker-key";
-            # the worker itself only stages inputs and packs outputs;
-            # store writes go through the nix-daemon socket
-            NoNewPrivileges = true;
-            PrivateTmp = true;
-            ProtectHome = true;
-            ProtectSystem = "strict";
-            RestrictSUIDSGID = true;
-            Restart = "on-failure";
-          };
         };
       };
     })

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -254,14 +254,19 @@ in
         # the memhog subtest relies on a plain memcg OOM kill
         boot.kernel.sysctl."vm.panic_on_oom" = lib.mkForce 0;
         virtualisation.diskSize = 4096;
+        # agents = "auto": one agent per core
+        virtualisation.cores = 2;
         virtualisation.additionalPaths = nspawnPaths;
 
         imports = [ nixosModule ];
         services.tribuchet-worker = {
           enable = true;
           package = tribuchet;
+          keyFile = "/etc/tribuchet/tls/worker.key";
           settings = {
             hub = "https://hub:7437";
+            cert = "/etc/tribuchet/tls/worker.crt";
+            ca-cert = "/etc/tribuchet/tls/ca.crt";
             max-jobs = 2;
             max-log-size = 1048576;
             # 2 GiB, exceeded only by the memhog subtest
@@ -294,16 +299,21 @@ in
         hub.succeed("tribuchet ca issue worker --dir /root/ca")
         hub.succeed("mkdir -p /etc/tribuchet/ca")
         hub.succeed("cp /root/ca/hub.crt /root/ca/hub.key /root/ca/ca.crt /etc/tribuchet/ca/")
-        worker.succeed("mkdir -p /var/lib/tribuchet/tls")
+        # certs are public, the key stays root-owned and reaches the
+        # DynamicUser worker via LoadCredential (keyFile)
+        worker.succeed("mkdir -p /etc/tribuchet/tls")
         for f in ["worker.crt", "worker.key", "ca.crt"]:
             pem = hub.succeed(f"cat /root/ca/{f}")
-            worker.succeed(f"cat > /var/lib/tribuchet/tls/{f} << 'PEMEOF'\n{pem}PEMEOF")
-        worker.succeed("chown -R tribuchet:tribuchet /var/lib/tribuchet/tls")
+            worker.succeed(f"cat > /etc/tribuchet/tls/{f} << 'PEMEOF'\n{pem}PEMEOF")
+        worker.succeed("chmod 600 /etc/tribuchet/tls/worker.key")
 
     with subtest("worker registers at hub over mTLS"):
         hub.succeed("systemctl start tribuchet-hub.socket")
         hub.succeed("systemctl start tribuchet-hub")
         worker.succeed("systemctl start tribuchet-worker")
+        # agents = "auto": the generator made one agent socket per core
+        worker.succeed("systemctl is-active tribuchet-agent@1.socket tribuchet-agent@2.socket")
+        worker.fail("systemctl is-active tribuchet-agent@3.socket")
         hub.wait_until_succeeds(
             "journalctl -u tribuchet-hub | grep -q 'worker registered'"
         )

--- a/nix/worker-units.nix
+++ b/nix/worker-units.nix
@@ -1,0 +1,123 @@
+# Worker and agent units shared by the NixOS module and the flakelet.
+# The worker runs unprivileged and leases every build to a per-uid,
+# socket-activated agent, which owns the builder process and its user
+# namespace, so builds survive worker restarts. Users are DynamicUser:
+# a host that defines tribuchet / tribuchet-agent-N statically wins.
+{
+  pkgs,
+  lib,
+  package,
+  # unit names differ: tribuchet-worker / tribuchet-agent@ vs <name> / <name>-agent@
+  workerUnit,
+  agentUnit,
+  # integer or "auto" (one per CPU, decided by a generator on the machine)
+  agents,
+  agentUidBase,
+  keyFile,
+  workerToml,
+}:
+let
+  auto = agents == "auto";
+  agentIds = map toString (lib.range 1 agents);
+  agentSocket = i: "${agentUnit}${i}.socket";
+  stateDir = "/var/lib/tribuchet/a%i";
+  # ExecStart cannot do arithmetic or resolve the worker's uid, which
+  # the agent needs for its peer-uid check.
+  agentStart = pkgs.writeShellScript "tribuchet-agent" ''
+    exec ${lib.getExe' package "tribuchet"} agent \
+      --state-dir "/var/lib/tribuchet/a$1" \
+      --uid-base "$(( ${toString agentUidBase} + ($1 - 1) * 65536 ))" \
+      --worker-uid "$(${lib.getExe' pkgs.coreutils "id"} -u tribuchet)"
+  '';
+in
+{
+  # Not under a RuntimeDirectory: systemd creates the socket parents and
+  # nothing removes them while agents keep running across worker stops.
+  agentSocketsDir = "/run/tribuchet/agents";
+
+  generators = lib.optionalAttrs auto {
+    agents = pkgs.writeShellScript "tribuchet-agents" ''
+      exec ${lib.getExe' package "tribuchet"} agent-generator \
+        --worker-unit ${workerUnit}.service --template ${agentSocket ""} "$@"
+    '';
+  };
+
+  agentInstances = lib.optionals (!auto) agentIds;
+
+  # The socket mode is open because the agent itself only accepts
+  # connections from the worker uid.
+  agentSocketConfig = {
+    description = "tribuchet build agent %i socket";
+    wantedBy = [ "sockets.target" ];
+    before = [ "${workerUnit}.service" ];
+    socketConfig = {
+      ListenStream = "/run/tribuchet/agents/%i.sock";
+      SocketMode = "0666";
+    };
+  };
+
+  agentServiceConfig = {
+    description = "tribuchet build agent %i";
+    # Exiting after every build is the agent's normal lifecycle.
+    unitConfig.StartLimitIntervalSec = 0;
+    # One build per activation: let it finish, the next lease runs the
+    # new ExecStart.
+    restartIfChanged = false;
+    serviceConfig = {
+      ExecStart = "${agentStart} %i";
+      DynamicUser = true;
+      User = "tribuchet-agent-%i";
+      # Not StateDirectory: DynamicUser would move it below the 0700
+      # /var/lib/private, out of reach for the worker and the uid block.
+      # Traverse-only: the per-build scratch dirs are world-writable for
+      # the block, but their names are random.
+      ExecStartPre = "+${pkgs.coreutils}/bin/install -d -m 0711 -o tribuchet-agent-%i -g tribuchet-agent-%i ${stateDir}";
+      ReadWritePaths = "/var/lib/tribuchet";
+      # Writing the uid/gid maps of the agent's user namespace needs
+      # CAP_SETUID/CAP_SETGID over the uid block, dropped right after.
+      # CAP_CHOWN stays: each build cgroup is handed to its mapped root.
+      AmbientCapabilities = [
+        "CAP_SETUID"
+        "CAP_SETGID"
+        "CAP_CHOWN"
+      ];
+      CapabilityBoundingSet = [
+        "CAP_SETUID"
+        "CAP_SETGID"
+        "CAP_CHOWN"
+      ];
+      # the per-build cgroup the sandbox roots its cgroup namespace in
+      Delegate = true;
+      # Builders inherit this; match nix-daemon to avoid EMFILE.
+      LimitNOFILE = 1048576;
+      Environment = "RUST_LOG=info";
+    };
+  };
+
+  workerServiceConfig = {
+    description = "tribuchet build worker";
+    wantedBy = [ "multi-user.target" ];
+    # the agent sockets must exist before the worker leases builds
+    wants = lib.optionals (!auto) (map agentSocket agentIds);
+    after = lib.optionals (!auto) (map agentSocket agentIds);
+    serviceConfig = {
+      Type = "notify";
+      DynamicUser = true;
+      User = "tribuchet";
+      WatchdogSec = "30";
+      ExecStart = "${lib.getExe' package "tribuchet"} worker --config ${workerToml}";
+      # Running builds live in the agent services and are re-adopted by
+      # the next worker instance.
+      StateDirectory = "tribuchet/worker";
+      Environment = [
+        "RUST_LOG=info"
+      ]
+      ++ lib.optional (keyFile != null) "TRIBUCHET_KEY=%d/worker-key";
+      ProtectHome = true;
+      Restart = "on-failure";
+    }
+    // lib.optionalAttrs (keyFile != null) {
+      LoadCredential = "worker-key:${keyFile}";
+    };
+  };
+}


### PR DESCRIPTION
Run hub/worker via flakelet (needs Mic92/flakelet#7). Worker/agent units are shared with the NixOS module (nix/worker-units.nix), use DynamicUser, and agents = "auto" sizes them per CPU with a systemd generator. Adds agent-sockets-dir to worker.toml.