### PR TITLE
add flakelet module for the worker

### DIFF
--- a/crates/tribuchet/src/config.rs
+++ b/crates/tribuchet/src/config.rs
@@ -227,6 +227,10 @@ pub struct WorkerConfig {
     /// agent count bounds concurrent builds.
     #[serde(default)]
     pub agent_sockets: Vec<PathBuf>,
+    /// Directory whose `*.sock` entries are appended to agent-sockets at
+    /// startup, for hosts that size the agent count at boot.
+    #[serde(default)]
+    pub agent_sockets_dir: Option<PathBuf>,
     /// Number of agents the worker spawns and supervises itself, for
     /// hosts without systemd-managed agent units such as containers.
     /// Mutually exclusive with agent-sockets.

--- a/crates/tribuchet/src/worker.rs
+++ b/crates/tribuchet/src/worker.rs
@@ -328,6 +328,16 @@ async fn run_async(opts: WorkerConfig) -> Result<()> {
                 agent_spawn::spawn(&opts.state_dir, opts.spawn_agents, opts.agent_uid_base)?;
         }
     }
+    if let Some(dir) = &opts.agent_sockets_dir {
+        let mut found: Vec<PathBuf> = std::fs::read_dir(dir)
+            .map_err(|e| err_msg(format!("agent-sockets-dir {}: {e}", dir.display())))?
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|x| x == "sock"))
+            .collect();
+        found.sort();
+        opts.agent_sockets.extend(found);
+    }
     // Every build runs on one agent, so the agent list bounds
     // concurrency.
     if opts.agent_sockets.is_empty() {

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,10 @@
 
       nixosModules.default = import ./nix/nixos-module.nix self;
 
+      # Run the hub via flakelet (https://github.com/Mic92/flakelet):
+      # units update from this flake independently of the host system.
+      flakelets.hub = import ./nix/flakelet-hub.nix { inherit crane; };
+
       # CI builds every package and devShell on every system, plus the
       # x86_64-linux-only checks below.
       checks = forAllSystems (

--- a/flake.nix
+++ b/flake.nix
@@ -63,9 +63,12 @@
 
       nixosModules.default = import ./nix/nixos-module.nix self;
 
-      # Run the hub via flakelet (https://github.com/Mic92/flakelet):
+      # Run hub/worker via flakelet (https://github.com/Mic92/flakelet):
       # units update from this flake independently of the host system.
-      flakelets.hub = import ./nix/flakelet-hub.nix { inherit crane; };
+      flakelets = {
+        hub = import ./nix/flakelet-hub.nix { inherit crane; };
+        worker = import ./nix/flakelet-worker.nix { inherit crane; };
+      };
 
       # CI builds every package and devShell on every system, plus the
       # x86_64-linux-only checks below.

--- a/nix/flakelet-hub.nix
+++ b/nix/flakelet-hub.nix
@@ -1,0 +1,124 @@
+# flakelet module for the hub (https://github.com/Mic92/flakelet).
+# Ships only the units. Firewall, the patched nix.package and the
+# nix.conf include stay host configuration.
+{ crane }:
+{ types, ... }:
+{
+  options = {
+    listenAddress = {
+      type = types.string;
+      default = "0.0.0.0";
+      description = "Address of the worker-facing gRPC listener.";
+    };
+    port = {
+      type = types.int;
+      default = 7437;
+      description = "Port of the worker-facing gRPC listener.";
+    };
+    socketPath = {
+      type = types.string;
+      defaultFunc = { inputs, ... }: "/run/${inputs.flakelet.name}/hub.sock";
+      description = "Attach socket path.";
+    };
+    socketGroup = {
+      type = types.string;
+      default = "nixbld";
+      description = "Group allowed to connect to the attach socket.";
+    };
+    configDir = {
+      type = types.string;
+      default = "/etc/tribuchet";
+      description = "Directory with the CA material and hub TLS key pair.";
+    };
+    nixConfigPath = {
+      type = types.option types.string;
+      description = "Enable dynamic external-builders: path of the hub-written nix.conf fragment.";
+    };
+    oversubscribePercent = {
+      type = types.int;
+      default = 200;
+    };
+    maxJobsCap = {
+      type = types.int;
+      default = 256;
+    };
+    hub = {
+      type = types.attrsOf types.any;
+      default = { };
+      description = "Extra hub.toml settings, merged verbatim.";
+    };
+  };
+
+  impl =
+    { options, inputs }:
+    let
+      inherit (inputs.nixpkgs) pkgs lib;
+      inherit (inputs.flakelet) name;
+      # Built against the host's nixpkgs like every flakelet; crane is a
+      # pure library and brings no nixpkgs of its own.
+      package = pkgs.callPackage ./package.nix { craneLib = crane.mkLib pkgs; };
+      format = pkgs.formats.toml { };
+      inherit (options)
+        listenAddress
+        port
+        configDir
+        socketPath
+        ;
+      attachWrapper = pkgs.writeShellScript "tribuchet-attach" ''
+        exec ${lib.getExe' package "tribuchet"} attach "$1" --socket ${socketPath}
+      '';
+      hubToml = format.generate "hub.toml" (
+        {
+          socket = socketPath;
+          listen = "${listenAddress}:${toString port}";
+          config-dir = configDir;
+        }
+        # Dynamic external-builders: the hub rewrites the host's nix.conf
+        # fragment as workers come and go. The attach program lives in this
+        # flakelet's closure, so generations keep it gc-rooted.
+        // lib.optionalAttrs (options.nixConfigPath != null) {
+          nix-config = {
+            path = options.nixConfigPath;
+            attach-program = toString attachWrapper;
+            oversubscribe-percent = options.oversubscribePercent;
+            max-jobs-cap = options.maxJobsCap;
+          };
+        }
+        // options.hub
+      );
+    in
+    {
+      sockets.${name} = {
+        description = "tribuchet hub sockets";
+        wantedBy = [ "sockets.target" ];
+        socketConfig = {
+          ListenStream = [
+            socketPath
+            "${listenAddress}:${toString port}"
+          ];
+          SocketGroup = options.socketGroup;
+          SocketMode = "0660";
+          # Owned by the socket unit so a service stop keeps the path.
+          RuntimeDirectory = name;
+        };
+      };
+
+      services.${name} = {
+        description = "tribuchet build hub";
+        wantedBy = [ "multi-user.target" ];
+        requires = [ "${name}.socket" ];
+        after = [ "${name}.socket" ];
+        serviceConfig = {
+          Type = "notify";
+          ExecStart = "${lib.getExe' package "tribuchet"} hub --config ${hubToml}";
+          RuntimeDirectory = name;
+          RuntimeDirectoryPreserve = true;
+          Environment = "RUST_LOG=info";
+          WatchdogSec = "30";
+          Restart = "on-failure";
+        };
+      };
+
+      exports.ports.workers = { inherit port; };
+    };
+}

--- a/nix/flakelet-worker.nix
+++ b/nix/flakelet-worker.nix
@@ -1,0 +1,126 @@
+# flakelet module for the worker and its per-uid build agents.
+# The host must still provide the `tribuchet` and `tribuchet-agent-N`
+# users (uids cannot come from a flakelet) and add tribuchet to
+# nix.settings.trusted-users. See nix/nixos-module.nix for the rationale
+# behind the agent architecture.
+{ crane }:
+{ types, ... }:
+{
+  options = {
+    agents = {
+      type = types.int;
+      defaultFunc = { options, ... }: options.worker.max-jobs or 64;
+      description = "Per-uid build agent count.";
+    };
+    agentUidBase = {
+      type = types.int;
+      default = 1325400064;
+      description = "First uid of the agents' 65536-uid blocks.";
+    };
+    keyFile = {
+      type = types.option types.string;
+      description = "TLS client key for the hub connection, loaded via LoadCredential.";
+    };
+    worker = {
+      type = types.attrsOf types.any;
+      description = "Contents of worker.toml; the hub key is required.";
+    };
+  };
+
+  impl =
+    { options, inputs }:
+    let
+      inherit (inputs.nixpkgs) pkgs lib;
+      inherit (inputs.flakelet) name;
+      package = pkgs.callPackage ./package.nix { craneLib = crane.mkLib pkgs; };
+      format = pkgs.formats.toml { };
+      agentIds = map toString (lib.range 1 options.agents);
+      inherit (options) keyFile;
+      # Not under a RuntimeDirectory: systemd creates the socket parents and
+      # nothing removes them while agents keep running across worker stops.
+      agentSocket = i: "/run/tribuchet/agents/${i}.sock";
+      # ExecStart cannot do arithmetic or resolve the worker's uid.
+      agentStart = pkgs.writeShellScript "tribuchet-agent" ''
+        exec ${lib.getExe' package "tribuchet"} agent \
+          --state-dir "/var/lib/tribuchet/a$1" \
+          --uid-base "$(( ${toString options.agentUidBase} + ($1 - 1) * 65536 ))" \
+          --worker-uid "$(${lib.getExe' pkgs.coreutils "id"} -u tribuchet)"
+      '';
+      workerToml = format.generate "worker.toml" (
+        {
+          agent-sockets = map agentSocket agentIds;
+        }
+        // options.worker
+      );
+      agentUnit = i: "${name}-agent@${i}.socket";
+    in
+    {
+      sockets."agent@" = {
+        description = "tribuchet build agent %i socket";
+        wantedBy = [ "sockets.target" ];
+        instances = agentIds;
+        socketConfig = {
+          ListenStream = agentSocket "%i";
+          # The agent itself only accepts connections from the worker uid.
+          SocketMode = "0666";
+        };
+      };
+
+      services."agent@" = {
+        description = "tribuchet build agent %i";
+        # Exiting after every build is the agent's normal lifecycle.
+        unitConfig.StartLimitIntervalSec = 0;
+        # One build per activation: let it finish, the next lease runs the
+        # new ExecStart.
+        restartIfChanged = false;
+        serviceConfig = {
+          ExecStart = "${agentStart} %i";
+          User = "tribuchet-agent-%i";
+          Group = "tribuchet-agent-%i";
+          StateDirectory = "tribuchet/a%i";
+          StateDirectoryMode = "0711";
+          AmbientCapabilities = [
+            "CAP_SETUID"
+            "CAP_SETGID"
+            "CAP_CHOWN"
+          ];
+          CapabilityBoundingSet = [
+            "CAP_SETUID"
+            "CAP_SETGID"
+            "CAP_CHOWN"
+          ];
+          Delegate = true;
+          LimitNOFILE = 1048576;
+          Environment = "RUST_LOG=info";
+        };
+      };
+
+      services.${name} = {
+        description = "tribuchet build worker";
+        wantedBy = [ "multi-user.target" ];
+        wants = map agentUnit agentIds;
+        after = map agentUnit agentIds;
+        serviceConfig = {
+          Type = "notify";
+          User = "tribuchet";
+          Group = "tribuchet";
+          WatchdogSec = "30";
+          ExecStart = "${lib.getExe' package "tribuchet"} worker --config ${workerToml}";
+          StateDirectory = "tribuchet/worker";
+          Environment = [
+            "RUST_LOG=info"
+          ]
+          ++ lib.optional (keyFile != null) "TRIBUCHET_KEY=%d/worker-key";
+          NoNewPrivileges = true;
+          PrivateTmp = true;
+          ProtectHome = true;
+          ProtectSystem = "strict";
+          RestrictSUIDSGID = true;
+          Restart = "on-failure";
+        }
+        // lib.optionalAttrs (keyFile != null) {
+          LoadCredential = "worker-key:${keyFile}";
+        };
+      };
+    };
+}

--- a/nix/flakelet-worker.nix
+++ b/nix/flakelet-worker.nix
@@ -10,7 +10,7 @@
     agents = {
       type = types.int;
       defaultFunc = { options, ... }: options.worker.max-jobs or 64;
-      description = "Per-uid build agent count.";
+      description = "Upper bound on build agents. The machine runs min(nproc, agents).";
     };
     agentUidBase = {
       type = types.int;
@@ -34,11 +34,10 @@
       inherit (inputs.flakelet) name;
       package = pkgs.callPackage ./package.nix { craneLib = crane.mkLib pkgs; };
       format = pkgs.formats.toml { };
-      agentIds = map toString (lib.range 1 options.agents);
       inherit (options) keyFile;
       # Not under a RuntimeDirectory: systemd creates the socket parents and
       # nothing removes them while agents keep running across worker stops.
-      agentSocket = i: "/run/tribuchet/agents/${i}.sock";
+      agentSocketsDir = "/run/tribuchet/agents";
       # ExecStart cannot do arithmetic or resolve the worker's uid.
       agentStart = pkgs.writeShellScript "tribuchet-agent" ''
         exec ${lib.getExe' package "tribuchet"} agent \
@@ -48,19 +47,29 @@
       '';
       workerToml = format.generate "worker.toml" (
         {
-          agent-sockets = map agentSocket agentIds;
+          agent-sockets-dir = agentSocketsDir;
         }
         // options.worker
       );
-      agentUnit = i: "${name}-agent@${i}.socket";
     in
     {
+      # One agent per CPU up to options.agents, decided on the machine.
+      generators.agents = pkgs.writeShellScript "agents" ''
+        n=$(nproc)
+        [ "$n" -gt ${toString options.agents} ] && n=${toString options.agents}
+        mkdir -p "$1/sockets.target.wants" "$1/${name}.service.wants"
+        for i in $(seq "$n"); do
+          ln -s /run/systemd/system/${name}-agent@.socket "$1/sockets.target.wants/${name}-agent@$i.socket"
+          ln -s /run/systemd/system/${name}-agent@.socket "$1/${name}.service.wants/${name}-agent@$i.socket"
+        done
+      '';
+
       sockets."agent@" = {
         description = "tribuchet build agent %i socket";
         wantedBy = [ "sockets.target" ];
-        instances = agentIds;
+        before = [ "${name}.service" ];
         socketConfig = {
-          ListenStream = agentSocket "%i";
+          ListenStream = "${agentSocketsDir}/%i.sock";
           # The agent itself only accepts connections from the worker uid.
           SocketMode = "0666";
         };
@@ -98,8 +107,6 @@
       services.${name} = {
         description = "tribuchet build worker";
         wantedBy = [ "multi-user.target" ];
-        wants = map agentUnit agentIds;
-        after = map agentUnit agentIds;
         serviceConfig = {
           Type = "notify";
           User = "tribuchet";


### PR DESCRIPTION
Stacked on #104. Ships the worker and its per-uid build agents as units updatable from this flake. The tribuchet and agent users plus trusted-users stay host configuration.