### PR TITLE
nix: split the e2e VM test into per-phase checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,9 @@ model, and failure handling in detail.
 $ nix develop            # rust toolchain + protobuf
 $ cargo test
 $ cargo clippy --all-targets
-$ nix build .#checks.x86_64-linux.nixos-test   # end-to-end VM test (hub + worker)
+$ nix build .#checks.x86_64-linux.nixos-test-builds     # end-to-end VM test (hub + worker)
+$ nix build .#checks.x86_64-linux.nixos-test-nspawn     # NixOS-container build in the sandbox
+$ nix build .#checks.x86_64-linux.nixos-test-lifecycle  # daemon restart/reload/stop sequence
 ```
 
 The VM test exercises remote builds, hub/worker restarts and reloads

--- a/flake.nix
+++ b/flake.nix
@@ -86,10 +86,27 @@
           );
         }
         // nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
-          nixos-test = pkgs.testers.runNixOSTest (
+          nixos-test-builds = pkgs.testers.runNixOSTest (
             import ./nix/test.nix {
               tribuchet = self.packages.x86_64-linux.default;
               nixosModule = self.nixosModules.default;
+              phase = "builds";
+            }
+          );
+
+          nixos-test-nspawn = pkgs.testers.runNixOSTest (
+            import ./nix/test.nix {
+              tribuchet = self.packages.x86_64-linux.default;
+              nixosModule = self.nixosModules.default;
+              phase = "nspawn";
+            }
+          );
+
+          nixos-test-lifecycle = pkgs.testers.runNixOSTest (
+            import ./nix/test.nix {
+              tribuchet = self.packages.x86_64-linux.default;
+              nixosModule = self.nixosModules.default;
+              phase = "lifecycle";
             }
           );
 

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -1,16 +1,29 @@
 # NixOS VM test: a real nix-daemon on `hub` routes a build through the
 # external-builders feature to tribuchet, which dispatches it to `worker`
 # over mTLS and unpacks the signed outputs back into the hub's store.
-{ tribuchet, nixosModule }:
+{
+  tribuchet,
+  nixosModule,
+  # "builds", "nspawn" or "lifecycle": independent derivations
+  # instead of one long serial run, and only nspawn seeds the ~900 MB
+  # container closure into the VM stores.
+  phase,
+}:
 { pkgs, lib, ... }:
 let
   # evaluated here so the container closure can be pre-seeded into both
   # VM stores; the hub re-evaluates the same expression at test time
   nspawn = import ./nspawn-container.nix { nixpkgs = pkgs.path; };
+  # the container closure and the stdenvNoCC that builds it stay out
+  # of the other phases' VM stores
+  nspawnPaths = lib.optionals (phase == "nspawn") [
+    pkgs.stdenvNoCC
+    nspawn.toplevel
+  ];
 
 in
 {
-  name = "tribuchet";
+  name = "tribuchet-${phase}";
 
   # Faster eval
   defaults.documentation.enable = false;
@@ -47,9 +60,8 @@ in
         virtualisation.additionalPaths = [
           pkgs.bash
           pkgs.coreutils
-          pkgs.stdenvNoCC
-          nspawn.toplevel
-        ];
+        ]
+        ++ nspawnPaths;
 
         nix.settings = {
           experimental-features = [
@@ -71,9 +83,13 @@ in
         environment.etc."tt/par.nix".text = ''
           import ${./tests/par.nix} { bash = "${pkgs.bash}"; }
         '';
-        environment.etc."tt/nspawn.nix".text = ''
-          import ${./nspawn-container.nix} { nixpkgs = ${pkgs.path}; }
-        '';
+        # references pkgs.path, which drags the full nixpkgs source
+        # into the hub closure. Only the nspawn phase pays for it.
+        environment.etc."tt/nspawn.nix" = lib.mkIf (phase == "nspawn") {
+          text = ''
+            import ${./nspawn-container.nix} { nixpkgs = ${pkgs.path}; }
+          '';
+        };
         environment.etc."tt/kvm.nix".text = ''
           import ${./tests/kvm.nix} { bash = "${pkgs.bash}"; }
         '';
@@ -223,10 +239,7 @@ in
         # the memhog subtest relies on a plain memcg OOM kill
         boot.kernel.sysctl."vm.panic_on_oom" = lib.mkForce 0;
         virtualisation.diskSize = 4096;
-        virtualisation.additionalPaths = [
-          pkgs.stdenvNoCC
-          nspawn.toplevel
-        ];
+        virtualisation.additionalPaths = nspawnPaths;
 
         imports = [ nixosModule ];
         services.tribuchet-worker = {
@@ -298,16 +311,28 @@ in
     })
     e2e = "${tribuchet.e2eTests}/bin/tribuchet-e2e"
 
-    # Phase 1: independent builds, multi-threaded. The worker/hub max-jobs
-    # queues bound real build concurrency; test-threads only caps ssh sessions.
+  ''
+  + lib.optionalString (phase == "builds") ''
+    # Independent builds, multi-threaded. The worker/hub max-jobs
+    # queues bound real build concurrency. test-threads only caps ssh
+    # sessions. build_nspawn runs in the nspawn phase.
     with subtest("parallel builds"):
         subprocess.run(
-            [e2e, "build_", "--nocapture", "--test-threads=8"],
+            [e2e, "build_", "--skip", "build_nspawn",
+             "--nocapture", "--test-threads=8"],
             env=e2e_env, check=True,
         )
-
-    # Phase 2: the stateful daemon-lifecycle sequence, serial and in order.
-    # Must run after phase 1: it restarts/reloads/stops the daemons.
+  ''
+  + lib.optionalString (phase == "nspawn") ''
+    with subtest("NixOS container build"):
+        subprocess.run(
+            [e2e, "build_nspawn", "--nocapture"],
+            env=e2e_env, check=True,
+        )
+  ''
+  + lib.optionalString (phase == "lifecycle") ''
+    # The stateful daemon-lifecycle sequence, serial and in order. It
+    # restarts/reloads/stops the daemons, so it gets its own VMs.
     with subtest("daemon lifecycle"):
         subprocess.run(
             [e2e, "lifecycle", "--nocapture", "--test-threads=1"],


### PR DESCRIPTION
nixos-test ran the build_* suite and the serial lifecycle sequence
back to back in one VM pair and seeded the ~900 MB nspawn container
closure (plus the nixpkgs source via the nspawn.nix shim) into every
run. The phases share no state.

Emit builds, nspawn and lifecycle as independent checks: parallel on
the builders, ~1 GB smaller VM images for the phases without the
container, one phase per iteration.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>