### PR TITLE
staging: optimistic streaming and dispatch lookahead

### DIFF
--- a/crates/tribuchet/src/hub/relay.rs
+++ b/crates/tribuchet/src/hub/relay.rs
@@ -1,18 +1,18 @@
 //! Per-job protocol with a worker: input staging, output relay and verification.
 
+mod extras;
 mod staging;
-use staging::{restage_inputs, stage_inputs, validate_missing};
+use extras::{ExtraImport, relay_extra_chunk, start_extras};
+use staging::{restage_inputs, stage_optimistic, validate_missing};
 
-use std::collections::HashMap;
-use std::io::{self, Write};
+use std::collections::{HashMap, HashSet};
+use std::io::Write;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-use futures_util::StreamExt as _;
-use harmonia_store_remote::DaemonStore as _;
 use harmonia_utils_signature::{PublicKey, Signature};
 use sha2::Digest;
-use tokio::io::AsyncReadExt as _;
 use tokio::sync::mpsc;
 use tonic::Status;
 
@@ -21,11 +21,10 @@ use super::state::{HubState, Job, Replay};
 use crate::capwrite::{CappedWriter, HashSink};
 use crate::errors::{Result, err_ctx, err_msg};
 use crate::proto::{
-    BuildAssignment, BuildResult, CancelBuild, ExtraPath, HubMessage, MAX_RESEND_ROUNDS,
-    NarTransfer, OutputNar, OutputSignature, PathOffer, ResultAck, attach_event, hub_message,
-    nar_transfer, worker_message,
+    BuildAssignment, BuildResult, CancelBuild, HubMessage, MAX_RESEND_ROUNDS, NarTransfer,
+    OutputNar, OutputSignature, PathOffer, ResultAck, attach_event, hub_message, nar_transfer,
+    worker_message,
 };
-use crate::store;
 
 /// How long a dispatched build may run with no attach client listening
 /// before the hub cancels it on the worker.
@@ -35,13 +34,33 @@ const CANCEL_GRACE: Duration = Duration::from_secs(10);
 /// time. Dedup of shared inputs happens on the worker.
 pub(super) struct WorkerStaging {
     permits: tokio::sync::Semaphore,
+    /// Paths this session's worker is believed to hold. Optimistic
+    /// streaming skips them. MissingPaths stays the authority: a
+    /// stale entry is restaged, costing bytes, never correctness.
+    sent: Mutex<HashSet<String>>,
 }
 
 impl WorkerStaging {
     pub(super) fn new() -> Self {
         Self {
             permits: tokio::sync::Semaphore::new(1),
+            sent: Mutex::new(HashSet::new()),
         }
+    }
+
+    pub(super) fn holds(&self, path: &str) -> bool {
+        self.sent.lock().unwrap().contains(path)
+    }
+
+    /// Record a path as held by the worker. Returns false if it
+    /// already was.
+    pub(super) fn mark_sent(&self, path: &str) -> bool {
+        self.sent.lock().unwrap().insert(path.to_string())
+    }
+
+    pub(super) fn mark_all_sent<'a>(&self, paths: impl Iterator<Item = &'a String>) {
+        let mut sent = self.sent.lock().unwrap();
+        sent.extend(paths.cloned());
     }
 }
 
@@ -89,10 +108,29 @@ pub(super) async fn run_job(
     )
     .await?;
 
-    let missing = loop {
-        match recv(&mut in_rx).await? {
+    // Stream the tmp dir and the sent-set complement without waiting
+    // for MissingPaths. The answer reconciles: anything requested
+    // beyond the optimistic stream goes out as a delta.
+    let streamed = Mutex::new(HashSet::new());
+    let (missing_tx, missing_rx) = tokio::sync::watch::channel(None);
+    let stage_fut = stage_optimistic(state, job, out_tx, &staging, &streamed, missing_rx);
+    tokio::pin!(stage_fut);
+    let mut staged = false;
+    let mut missing: Option<Vec<String>> = None;
+    while !(staged && missing.is_some()) {
+        let m = tokio::select! {
+            r = &mut stage_fut, if !staged => {
+                r?;
+                staged = true;
+                continue;
+            }
+            m = recv(&mut in_rx) => m?,
+        };
+        match m {
             // The worker already holds this build (it survived a hub
             // restart); skip staging, its result arrives like any other.
+            // Optimistically streamed bytes land on a build id the
+            // worker no longer stages and are dropped there.
             worker_message::Msg::Resumed(_) => {
                 tracing::info!(id = job.id, "worker resumed an in-flight build");
                 return relay_build(state, job, vkey, out_tx, &mut in_rx, &staging)
@@ -104,8 +142,13 @@ pub(super) async fn run_job(
             worker_message::Msg::Log(l) => {
                 job.replay.publish(attach_event::Event::Log(l.data)).await;
             }
-            worker_message::Msg::MissingPaths(m) => {
-                break validate_missing(&req.input_paths, m.store_paths)?;
+            worker_message::Msg::MissingPaths(m) if missing.is_none() => {
+                let m = validate_missing(&req.input_paths, m.store_paths)?;
+                // Offered but not missing means confirmed present.
+                let missing_set: HashSet<&String> = m.iter().collect();
+                staging.mark_all_sent(req.input_paths.iter().filter(|p| !missing_set.contains(*p)));
+                let _ = missing_tx.send(Some(m.clone()));
+                missing = Some(m);
             }
             // Staging failed worker-side (assignment validation, its
             // nix-daemon unreachable, ...): the worker reports it as a
@@ -122,15 +165,28 @@ pub(super) async fn run_job(
                 )));
             }
         }
+    }
+    let missing = missing.unwrap();
+    let (delta, streamed_count) = {
+        let streamed = streamed.lock().unwrap();
+        let delta: Vec<String> = missing
+            .iter()
+            .filter(|p| !streamed.contains(*p))
+            .cloned()
+            .collect();
+        (delta, streamed.len())
     };
     tracing::info!(
         id = job.id,
         total = req.input_paths.len(),
         missing = missing.len(),
+        streamed = streamed_count,
+        delta = delta.len(),
         "input path negotiation done"
     );
-
-    stage_inputs(state, job, out_tx, &staging, &missing).await?;
+    if !delta.is_empty() {
+        restage_inputs(state, job, out_tx, &staging, &delta).await?;
+    }
     relay_build(state, job, vkey, out_tx, &mut in_rx, &staging)
         .await
         .map(|_| ())
@@ -211,67 +267,6 @@ fn verify_set(
     Ok(pending)
 }
 
-/// In-flight AddToStoreNar of one recursive-nix extra. Chunks stream
-/// through `tx` into a daemon-pool connection held by `task`.
-struct ExtraImport {
-    tx: mpsc::Sender<bytes::Bytes>,
-    task: tokio::task::JoinHandle<Result<()>>,
-}
-
-/// Verify each extra's worker signature over `path:nar_sha256_hex`
-/// (the same envelope as outputs) and spawn the daemon import. The
-/// daemon then verifies on its end that the NAR matches the signed
-/// hash.
-fn start_extras(
-    state: &HubState,
-    vkey: &PublicKey,
-    reported: Vec<ExtraPath>,
-) -> Result<HashMap<String, ExtraImport>> {
-    let mut out = HashMap::with_capacity(reported.len());
-    for extra in reported {
-        let info = extra
-            .info
-            .ok_or_else(|| err_msg("extra without PathInfo"))?;
-        let path = info.store_path.clone();
-        let sig: Signature = extra
-            .signature
-            .parse()
-            .map_err(err_ctx("malformed extra signature"))?;
-        let envelope = format!("{}:{}", path, hex::encode(&info.nar_sha256));
-        if !vkey.verify(envelope.as_bytes(), &sig) {
-            return Err(err_msg(format!(
-                "signature verification failed for extra {path}"
-            )));
-        }
-        let parsed = store::parse_path_info(&info).map_err(err_ctx("parsing extra PathInfo"))?;
-        let (tx, rx) = mpsc::channel::<bytes::Bytes>(8);
-        let pool = state.daemon_pool.clone();
-        let task = tokio::spawn(async move { import_extra(&pool, parsed, rx).await });
-        out.insert(path, ExtraImport { tx, task });
-    }
-    Ok(out)
-}
-
-async fn import_extra(
-    pool: &harmonia_store_remote::ConnectionPool,
-    info: harmonia_store_path_info::ValidPathInfo,
-    rx: mpsc::Receiver<bytes::Bytes>,
-) -> Result<()> {
-    let mut guard = pool
-        .acquire()
-        .await
-        .map_err(err_ctx("connecting to the local nix-daemon"))?;
-    let stream = tokio_stream::wrappers::ReceiverStream::new(rx).map(Ok::<_, io::Error>);
-    let reader = tokio_util::io::StreamReader::new(stream);
-    let dec =
-        async_compression::tokio::bufread::ZstdDecoder::new(tokio::io::BufReader::new(reader));
-    let limited = tokio::io::BufReader::new(dec.take(info.info.nar_size));
-    guard
-        .execute(|c| c.add_to_store_nar(&info, limited, false, true))
-        .await
-        .map_err(|e| err_msg(format!("registering extra {} via daemon: {e}", info.path)))
-}
-
 async fn relay_output_chunk(
     vkey: &PublicKey,
     pending: &mut HashMap<String, OutputVerify>,
@@ -306,32 +301,6 @@ async fn relay_output_chunk(
                 zstd_nar_chunk: Vec::new(),
                 eof: true,
             }))
-            .await;
-    }
-    Ok(())
-}
-
-async fn relay_extra_chunk(
-    extras: &mut HashMap<String, ExtraImport>,
-    replay: &Replay,
-    n: NarTransfer,
-) -> Result<()> {
-    let extra = extras.get_mut(&n.store_path).unwrap();
-    if let Some(nar_transfer::Payload::ZstdNarChunk(chunk)) = n.payload
-        && extra.tx.send(chunk.into()).await.is_err()
-    {
-        // rx closed does not imply failure: the import reads via
-        // take(nar_size) and drops rx once done.
-        let extra = extras.remove(&n.store_path).unwrap();
-        extra.task.await??;
-        return Err(err_msg(format!("excess extra chunks for {}", n.store_path)));
-    }
-    if n.eof {
-        let extra = extras.remove(&n.store_path).unwrap();
-        drop(extra.tx);
-        extra.task.await??;
-        replay
-            .publish(attach_event::Event::AddedPath(n.store_path))
             .await;
     }
     Ok(())
@@ -503,48 +472,5 @@ async fn relay_build(
                 )));
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use harmonia_utils_signature::SecretKey;
-
-    use crate::proto::PathInfoMsg;
-
-    use super::*;
-
-    /// Wrong-key signatures must fail before any daemon contact, so a
-    /// compromised worker cannot plant store paths on the client.
-    #[tokio::test]
-    async fn extras_with_wrong_signature_are_rejected() {
-        let hub_sk = SecretKey::generate("hub-trusted-key-1".into()).unwrap();
-        let attacker_sk = SecretKey::generate("attacker-1".into()).unwrap();
-        let vkey = hub_sk.to_public_key();
-
-        let path = format!("/nix/store/{}-extra", "0".repeat(32));
-        let nar_sha256 = vec![0u8; 32];
-        let envelope = format!("{path}:{}", hex::encode(&nar_sha256));
-        let bad = ExtraPath {
-            info: Some(PathInfoMsg {
-                build_id: String::new(),
-                store_path: path.clone(),
-                nar_sha256: nar_sha256.clone(),
-                nar_size: 1024,
-                references: vec![],
-                signatures: vec![],
-                deriver: String::new(),
-                ca: String::new(),
-            }),
-            signature: attacker_sk.sign(envelope.as_bytes()).to_string(),
-        };
-        let state = HubState::default();
-        let err = start_extras(&state, &vkey, vec![bad])
-            .err()
-            .expect("expected signature rejection");
-        assert!(
-            err.to_string().contains("signature verification failed"),
-            "{err}"
-        );
     }
 }

--- a/crates/tribuchet/src/hub/relay/extras.rs
+++ b/crates/tribuchet/src/hub/relay/extras.rs
@@ -1,0 +1,143 @@
+//! Recursive-nix extras: signature verification and daemon import of
+//! store paths a build added beyond its outputs.
+
+use std::collections::HashMap;
+use std::io;
+
+use futures_util::StreamExt as _;
+use harmonia_store_remote::DaemonStore as _;
+use harmonia_utils_signature::{PublicKey, Signature};
+use tokio::io::AsyncReadExt as _;
+use tokio::sync::mpsc;
+
+use super::super::state::{HubState, Replay};
+use crate::errors::{Result, err_ctx, err_msg};
+use crate::proto::{ExtraPath, NarTransfer, attach_event, nar_transfer};
+use crate::store;
+
+/// In-flight AddToStoreNar of one recursive-nix extra. Chunks stream
+/// through `tx` into a daemon-pool connection held by `task`.
+pub(super) struct ExtraImport {
+    tx: mpsc::Sender<bytes::Bytes>,
+    task: tokio::task::JoinHandle<Result<()>>,
+}
+
+/// Verify each extra's worker signature over `path:nar_sha256_hex`
+/// (the same envelope as outputs) and spawn the daemon import.
+pub(super) fn start_extras(
+    state: &HubState,
+    vkey: &PublicKey,
+    reported: Vec<ExtraPath>,
+) -> Result<HashMap<String, ExtraImport>> {
+    let mut out = HashMap::with_capacity(reported.len());
+    for extra in reported {
+        let info = extra
+            .info
+            .ok_or_else(|| err_msg("extra without PathInfo"))?;
+        let path = info.store_path.clone();
+        let sig: Signature = extra
+            .signature
+            .parse()
+            .map_err(err_ctx("malformed extra signature"))?;
+        let envelope = format!("{}:{}", path, hex::encode(&info.nar_sha256));
+        if !vkey.verify(envelope.as_bytes(), &sig) {
+            return Err(err_msg(format!(
+                "signature verification failed for extra {path}"
+            )));
+        }
+        let parsed = store::parse_path_info(&info).map_err(err_ctx("parsing extra PathInfo"))?;
+        let (tx, rx) = mpsc::channel::<bytes::Bytes>(8);
+        let pool = state.daemon_pool.clone();
+        let task = tokio::spawn(async move { import_extra(&pool, parsed, rx).await });
+        out.insert(path, ExtraImport { tx, task });
+    }
+    Ok(out)
+}
+
+async fn import_extra(
+    pool: &harmonia_store_remote::ConnectionPool,
+    info: harmonia_store_path_info::ValidPathInfo,
+    rx: mpsc::Receiver<bytes::Bytes>,
+) -> Result<()> {
+    let mut guard = pool
+        .acquire()
+        .await
+        .map_err(err_ctx("connecting to the local nix-daemon"))?;
+    let stream = tokio_stream::wrappers::ReceiverStream::new(rx).map(Ok::<_, io::Error>);
+    let reader = tokio_util::io::StreamReader::new(stream);
+    let dec =
+        async_compression::tokio::bufread::ZstdDecoder::new(tokio::io::BufReader::new(reader));
+    let limited = tokio::io::BufReader::new(dec.take(info.info.nar_size));
+    guard
+        .execute(|c| c.add_to_store_nar(&info, limited, false, true))
+        .await
+        .map_err(|e| err_msg(format!("registering extra {} via daemon: {e}", info.path)))
+}
+
+pub(super) async fn relay_extra_chunk(
+    extras: &mut HashMap<String, ExtraImport>,
+    replay: &Replay,
+    n: NarTransfer,
+) -> Result<()> {
+    let extra = extras.get_mut(&n.store_path).unwrap();
+    if let Some(nar_transfer::Payload::ZstdNarChunk(chunk)) = n.payload
+        && extra.tx.send(chunk.into()).await.is_err()
+    {
+        // rx closed does not imply failure: the import reads via
+        // take(nar_size) and drops rx once done.
+        let extra = extras.remove(&n.store_path).unwrap();
+        extra.task.await??;
+        return Err(err_msg(format!("excess extra chunks for {}", n.store_path)));
+    }
+    if n.eof {
+        let extra = extras.remove(&n.store_path).unwrap();
+        drop(extra.tx);
+        extra.task.await??;
+        replay
+            .publish(attach_event::Event::AddedPath(n.store_path))
+            .await;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use harmonia_utils_signature::SecretKey;
+
+    use super::*;
+    use crate::proto::PathInfoMsg;
+
+    /// Wrong-key signatures must fail before any daemon contact, so a
+    /// compromised worker cannot plant store paths on the client.
+    #[tokio::test]
+    async fn extras_with_wrong_signature_are_rejected() {
+        let hub_sk = SecretKey::generate("hub-trusted-key-1".into()).unwrap();
+        let attacker_sk = SecretKey::generate("attacker-1".into()).unwrap();
+        let vkey = hub_sk.to_public_key();
+
+        let path = format!("/nix/store/{}-extra", "0".repeat(32));
+        let nar_sha256 = vec![0u8; 32];
+        let envelope = format!("{path}:{}", hex::encode(&nar_sha256));
+        let bad = ExtraPath {
+            info: Some(PathInfoMsg {
+                build_id: String::new(),
+                store_path: path.clone(),
+                nar_sha256: nar_sha256.clone(),
+                nar_size: 1024,
+                references: vec![],
+                signatures: vec![],
+                deriver: String::new(),
+                ca: String::new(),
+            }),
+            signature: attacker_sk.sign(envelope.as_bytes()).to_string(),
+        };
+        let state = HubState::default();
+        let err = start_extras(&state, &vkey, vec![bad])
+            .err()
+            .expect("expected signature rejection");
+        assert!(
+            err.to_string().contains("signature verification failed"),
+            "{err}"
+        );
+    }
+}

--- a/crates/tribuchet/src/hub/relay/staging.rs
+++ b/crates/tribuchet/src/hub/relay/staging.rs
@@ -2,11 +2,12 @@
 
 use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
+use std::sync::Mutex;
 
 use harmonia_store_path::{StoreDir, StorePath};
 use harmonia_store_remote::DaemonStore as _;
 use tokio::io::AsyncReadExt as _;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tonic::Status;
 
 use super::super::state::{HubState, Job};
@@ -36,29 +37,53 @@ pub(super) fn validate_missing(
     Ok(missing)
 }
 
-/// Stream this build's missing inputs and tmp dir under the session's
-/// staging permit.
-pub(super) async fn stage_inputs(
+/// Tmp dir first, then the offer minus the sent-set. With no
+/// session knowledge of the offer, wait for MissingPaths instead of
+/// blasting a possibly warm worker. Streamed paths are recorded for
+/// the caller's delta.
+pub(super) async fn stage_optimistic(
     state: &HubState,
     job: &Job,
     out_tx: &mpsc::Sender<Result<HubMessage, Status>>,
     staging: &WorkerStaging,
-    missing: &[String],
+    streamed: &Mutex<HashSet<String>>,
+    mut missing_rx: watch::Receiver<Option<Vec<String>>>,
 ) -> Result<()> {
-    // Serialize only the import: negotiation before this is read-only
-    // on the worker store, so it runs in parallel (bounded by
-    // RequestJob credits) instead of gating throughput on its
-    // round-trip.
     let _permit = staging
         .permits
         .acquire()
         .await
         .expect("staging semaphore closed");
-    stream_inputs(state, job, out_tx, missing).await?;
-    stream_tmp_dir(&job.id, &job.tmp_dir_pack, out_tx).await
+    stream_tmp_dir(&job.id, &job.tmp_dir_pack, out_tx).await?;
+    let complement: Vec<String> = job
+        .req
+        .input_paths
+        .iter()
+        .filter(|p| !staging.holds(p))
+        .cloned()
+        .collect();
+    let candidates = if complement.len() == job.req.input_paths.len() {
+        let missing = missing_rx
+            .wait_for(Option::is_some)
+            .await
+            .map_err(|_| err_msg("build gone before the MissingPaths answer"))?;
+        missing.clone().unwrap()
+    } else {
+        complement
+    };
+    stream_inputs(state, job, out_tx, &candidates, &mut |p| {
+        if staging.mark_sent(p) {
+            streamed.lock().unwrap().insert(p.to_string());
+            true
+        } else {
+            false
+        }
+    })
+    .await
 }
 
-/// Stream inputs re-requested after staging, then send StagingComplete.
+/// Stream inputs the worker asked for beyond the optimistic stream,
+/// then send StagingComplete.
 pub(super) async fn restage_inputs(
     state: &HubState,
     job: &Job,
@@ -71,7 +96,8 @@ pub(super) async fn restage_inputs(
         .acquire()
         .await
         .expect("staging semaphore closed");
-    stream_inputs(state, job, out_tx, missing).await?;
+    stream_inputs(state, job, out_tx, missing, &mut |_| true).await?;
+    staging.mark_all_sent(missing.iter());
     send(
         out_tx,
         hub_message::Msg::StagingComplete(StagingComplete {
@@ -91,6 +117,7 @@ async fn stream_inputs(
     job: &Job,
     out_tx: &mpsc::Sender<Result<HubMessage, Status>>,
     paths: &[String],
+    admit: &mut (dyn FnMut(&str) -> bool + Send),
 ) -> Result<()> {
     let infos = order_by_references(query_path_infos(&state.daemon_pool, paths).await?);
     let mut infos = infos.into_iter();
@@ -98,6 +125,9 @@ async fn stream_inputs(
     loop {
         while inflight.len() < PACK_PIPELINE {
             let Some(info) = infos.next() else { break };
+            if !admit(&info.store_path) {
+                continue;
+            }
             let pack = spawn_pack(&info.store_path);
             inflight.push_back((info, pack));
         }

--- a/crates/tribuchet/src/worker/build.rs
+++ b/crates/tribuchet/src/worker/build.rs
@@ -96,6 +96,9 @@ pub(super) struct ActiveBuild {
     /// True once the tmp dir stream finished unpacking.
     tmp_dir_done: bool,
     resend_rounds: u32,
+    /// A NeedResend answer is on the wire. A StagingComplete crossing
+    /// it belongs to the superseded round and is ignored.
+    awaiting_resend: bool,
     /// Daemon connection; carries this build's temp roots, so it must
     /// outlive the build.
     daemon: Option<DaemonConn>,
@@ -134,6 +137,7 @@ impl ActiveBuild {
             registered: HashSet::new(),
             tmp_dir_done: false,
             resend_rounds: 0,
+            awaiting_resend: false,
             daemon: None,
             imports: HashMap::new(),
             pool: None,
@@ -253,8 +257,17 @@ impl ActiveBuild {
         }
     }
 
+    /// Unrequested paths (already valid here, or deferred to
+    /// another build's import) arrive anyway and are dropped.
+    fn tolerated(&self, path: &str) -> bool {
+        self.inputs.iter().any(|p| p == path) || self.deferred.iter().any(|p| p == path)
+    }
+
     pub(super) fn feed_path_info(&mut self, pi: &PathInfoMsg) -> Result<()> {
         let Some(slot) = self.pending.get_mut(&pi.store_path) else {
+            if self.tolerated(&pi.store_path) {
+                return Ok(());
+            }
             return Err(err_msg(format!(
                 "hub sent path info for unrequested path {}",
                 pi.store_path
@@ -271,7 +284,7 @@ impl ActiveBuild {
         Ok(())
     }
 
-    pub(super) async fn feed_nar(&mut self, n: NarTransfer) -> Result<()> {
+    pub(super) async fn feed_nar(&mut self, n: NarTransfer) -> Result<StagingStatus> {
         if !self.imports.contains_key(&n.store_path) {
             let info = match self.pending.remove(&n.store_path) {
                 Some(Some(info)) => info,
@@ -282,6 +295,9 @@ impl ActiveBuild {
                     )));
                 }
                 None => {
+                    if self.tolerated(&n.store_path) {
+                        return Ok(StagingStatus::InProgress);
+                    }
                     return Err(err_msg(format!(
                         "hub sent NAR for unrequested path {}",
                         n.store_path
@@ -344,11 +360,12 @@ impl ActiveBuild {
             });
         }
         if n.eof {
-            // Import completion is reaped in complete_staging. The
+            // Import completion is reaped when staging finishes. The
             // next NAR dispatches to another pool connection now.
             handle.tx = None;
+            return self.try_complete().await;
         }
-        Ok(())
+        Ok(StagingStatus::InProgress)
     }
 
     /// Reports staging progress; the tmp dir eof completes round one.
@@ -376,7 +393,7 @@ impl ActiveBuild {
             drop(tx);
             task.await??;
             self.tmp_dir_done = true;
-            return self.complete_staging().await;
+            return self.try_complete().await;
         }
         Ok(StagingStatus::InProgress)
     }
@@ -385,6 +402,9 @@ impl ActiveBuild {
     /// requested NAR must have arrived; deferred paths that are still
     /// invalid are re-requested instead of failing the build.
     pub(super) async fn complete_staging(&mut self) -> Result<StagingStatus> {
+        if self.awaiting_resend {
+            return Ok(StagingStatus::InProgress);
+        }
         if !self.tmp_dir_done {
             return Err(err_msg(
                 "hub signalled staging completion before the tmp dir arrived",
@@ -395,13 +415,30 @@ impl ActiveBuild {
                 "hub never sent a NAR for requested input {p}"
             )));
         }
+        if let Some((p, _)) = self.imports.iter().find(|(_, h)| h.tx.is_some()) {
+            return Err(err_msg(format!(
+                "staging round ended during the NAR transfer of {p}"
+            )));
+        }
+        self.finish_staging().await
+    }
+
+    /// Staging finishes once the tmp dir is unpacked and every
+    /// requested NAR is fully fed, checked from both eof paths.
+    async fn try_complete(&mut self) -> Result<StagingStatus> {
+        if !self.tmp_dir_done
+            || !self.pending.is_empty()
+            || self.imports.values().any(|h| h.tx.is_some())
+        {
+            return Ok(StagingStatus::InProgress);
+        }
+        self.finish_staging().await
+    }
+
+    async fn finish_staging(&mut self) -> Result<StagingStatus> {
+        self.awaiting_resend = false;
         let imports: Vec<(String, ImportHandle)> = self.imports.drain().collect();
         for (path, mut h) in imports {
-            if h.tx.is_some() {
-                return Err(err_msg(format!(
-                    "staging round ended during the NAR transfer of {path}"
-                )));
-            }
             let state = h
                 .done
                 .wait_for(|s| !matches!(s, ImportState::Running))
@@ -448,6 +485,7 @@ impl ActiveBuild {
             )));
         }
         self.resend_rounds += 1;
+        self.awaiting_resend = true;
         // This build imports them itself now: claim and expect them.
         let mut inflight = self.ctx.staging_inflight.lock().unwrap();
         for p in &still_missing {

--- a/crates/tribuchet/src/worker/session.rs
+++ b/crates/tribuchet/src/worker/session.rs
@@ -1,6 +1,6 @@
 //! Hub session: connect, register, and drive the per-build message loop.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::fs;
 use std::sync::Arc;
 use std::time::Duration;
@@ -104,13 +104,27 @@ async fn session_loop(
     build_timeout: Duration,
     max_jobs: u32,
 ) -> Result<()> {
+    let env = LaunchEnv {
+        ctx,
+        out_tx,
+        signing_key,
+        build_timeout,
+    };
     // Permits already funded to the hub but not yet assigned back.
     let mut pending = Vec::new();
+    // Builds staged to completion but waiting for a free slot.
+    let mut ready: VecDeque<String> = VecDeque::new();
     let mut heartbeat = tokio::time::interval(Duration::from_secs(30));
+    // One unfunded request beyond the free slots: the hub assigns and
+    // stages the next build while every slot is busy, so a finishing
+    // build hands its slot to a build that starts immediately instead
+    // of waiting a round trip plus staging.
+    out_tx.send(request_job()).await?;
     loop {
         let m = tokio::select! {
             permit = ctx.slots.clone().acquire_owned() => {
-                pending.push(permit.expect("slots never closed"));
+                let permit = permit.expect("slots never closed");
+                grant_slot(permit, active, &mut ready, &mut pending, &env);
                 out_tx.send(request_job()).await?;
                 continue;
             }
@@ -155,31 +169,20 @@ async fn session_loop(
                     // A NAR eof can complete staging: the hub streams
                     // optimistically, so the tmp dir may already be done.
                     let res = build.feed_nar(n).await;
-                    advance_staging(active, &id, res, ctx, out_tx, signing_key, build_timeout)
-                        .await?;
+                    advance_staging(active, &mut ready, &id, res, &env).await?;
                 }
             }
             hub_message::Msg::TmpDir(t) => {
                 let id = t.build_id.clone();
                 if let Some(build) = active.get_mut(&id) {
                     let res = build.feed_tmp_dir(t).await;
-                    advance_staging(active, &id, res, ctx, out_tx, signing_key, build_timeout)
-                        .await?;
+                    advance_staging(active, &mut ready, &id, res, &env).await?;
                 }
             }
             hub_message::Msg::StagingComplete(s) => {
                 if let Some(build) = active.get_mut(&s.build_id) {
                     let res = build.complete_staging().await;
-                    advance_staging(
-                        active,
-                        &s.build_id,
-                        res,
-                        ctx,
-                        out_tx,
-                        signing_key,
-                        build_timeout,
-                    )
-                    .await?;
+                    advance_staging(active, &mut ready, &s.build_id, res, &env).await?;
                 }
             }
             hub_message::Msg::PathInfo(pi) => {
@@ -201,19 +204,35 @@ async fn session_loop(
 /// Act on a staging step: launch, request an input resend, or abort.
 async fn advance_staging(
     active: &mut HashMap<String, ActiveBuild>,
+    ready: &mut VecDeque<String>,
     id: &str,
     res: Result<StagingStatus>,
-    ctx: &Arc<WorkerCtx>,
-    out_tx: &mpsc::Sender<WorkerMessage>,
-    signing_key: &Arc<SecretKey>,
-    build_timeout: Duration,
+    env: &LaunchEnv<'_>,
 ) -> Result<()> {
     match res {
-        Err(e) => abort_active(active, id, out_tx, &e).await?,
+        Err(e) => abort_active(active, id, env.out_tx, &e).await?,
         Ok(StagingStatus::InProgress) => {}
         Ok(StagingStatus::Ready) => {
+            // The lookahead assignment carries no permit. Grab a free
+            // slot (funding its advertisement ourselves) or queue
+            // until one frees.
+            let build = active.get_mut(id).unwrap();
+            if build.permit.is_none() {
+                let Ok(p) = env.ctx.slots.clone().try_acquire_owned() else {
+                    ready.push_back(id.to_string());
+                    return Ok(());
+                };
+                build.permit = Some(p);
+                env.out_tx.send(request_job()).await?;
+            }
             let build = active.remove(id).unwrap();
-            launch_build(ctx, build, out_tx, signing_key, build_timeout);
+            launch_build(
+                env.ctx,
+                build,
+                env.out_tx,
+                env.signing_key,
+                env.build_timeout,
+            );
         }
         Ok(StagingStatus::NeedResend(paths)) => {
             tracing::info!(
@@ -221,7 +240,7 @@ async fn advance_staging(
                 count = paths.len(),
                 "re-requesting inputs another build failed to import"
             );
-            out_tx
+            env.out_tx
                 .send(msg(worker_message::Msg::MissingPaths(MissingPaths {
                     build_id: id.to_string(),
                     store_paths: paths,
@@ -231,6 +250,7 @@ async fn advance_staging(
     }
     Ok(())
 }
+
 /// Cancel a build. Still staging: tear it down right here. Already
 /// executing: flag its dedupe key for the supervising loop. The key
 /// is the stable identity, the build_id the hub knows may predate a
@@ -258,6 +278,43 @@ async fn handle_cancel(
         }
     }
     Ok(())
+}
+
+/// Everything needed to launch a staged build.
+struct LaunchEnv<'a> {
+    ctx: &'a Arc<WorkerCtx>,
+    out_tx: &'a mpsc::Sender<WorkerMessage>,
+    signing_key: &'a Arc<SecretKey>,
+    build_timeout: Duration,
+}
+
+/// Hand a freed slot to a staged build waiting for one, or advertise
+/// it to the hub as pending.
+fn grant_slot(
+    permit: tokio::sync::OwnedSemaphorePermit,
+    active: &mut HashMap<String, ActiveBuild>,
+    ready: &mut VecDeque<String>,
+    pending: &mut Vec<tokio::sync::OwnedSemaphorePermit>,
+    env: &LaunchEnv<'_>,
+) {
+    let mut permit = Some(permit);
+    while let Some(id) = ready.pop_front() {
+        // cancel may have removed it from active
+        if let Some(mut build) = active.remove(&id) {
+            build.permit = permit.take();
+            launch_build(
+                env.ctx,
+                build,
+                env.out_tx,
+                env.signing_key,
+                env.build_timeout,
+            );
+            break;
+        }
+    }
+    if let Some(p) = permit {
+        pending.push(p);
+    }
 }
 
 /// Adopt a re-dispatched build or stage a fresh assignment.

--- a/crates/tribuchet/src/worker/session.rs
+++ b/crates/tribuchet/src/worker/session.rs
@@ -152,9 +152,11 @@ async fn session_loop(
                 let id = n.build_id.clone();
                 if let Some(build) = active.get_mut(&id) {
                     // A bad transfer fails this build, not the session.
-                    if let Err(e) = build.feed_nar(n).await {
-                        abort_active(active, &id, out_tx, &e).await?;
-                    }
+                    // A NAR eof can complete staging: the hub streams
+                    // optimistically, so the tmp dir may already be done.
+                    let res = build.feed_nar(n).await;
+                    advance_staging(active, &id, res, ctx, out_tx, signing_key, build_timeout)
+                        .await?;
                 }
             }
             hub_message::Msg::TmpDir(t) => {


### PR DESCRIPTION
Stream inputs without waiting for MissingPaths (warm workers launch with zero staging round trips) and keep one RequestJob outstanding so the next build stages while slots are busy.