### PR TITLE
hub: serve cached chunks by hash without repacking

### DIFF
--- a/crates/tribuchet/src/hub.rs
+++ b/crates/tribuchet/src/hub.rs
@@ -9,8 +9,6 @@
 //! - verifies worker output signatures while relaying compressed chunks
 
 use std::collections::{HashMap, HashSet};
-#[cfg(target_os = "macos")]
-use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};

--- a/crates/tribuchet/src/hub/chunkcache.rs
+++ b/crates/tribuchet/src/hub/chunkcache.rs
@@ -76,6 +76,15 @@ impl ChunkCache {
         Disposition::FirstSeen
     }
 
+    /// Locate every hash under one lock. None unless all are cached.
+    pub fn locate_all(&self, hashes: &HashSet<Hash>) -> Option<Vec<(Hash, FrameRef)>> {
+        let mut inner = self.inner.lock().unwrap();
+        hashes
+            .iter()
+            .map(|h| inner.store.locate(h).map(|f| (*h, f)))
+            .collect()
+    }
+
     pub fn recipe(&self, store_path: &str) -> Option<Recipe> {
         self.inner.lock().unwrap().recipes.get(store_path).cloned()
     }

--- a/crates/tribuchet/src/hub/relay/staging/chunked.rs
+++ b/crates/tribuchet/src/hub/relay/staging/chunked.rs
@@ -101,7 +101,11 @@ pub(in crate::hub) async fn stage_chunked(
             continue;
         }
         served.extend(&todo);
-        stream_path_chunks(cache, job, &info.store_path, todo, &mut run, out_tx).await?;
+        let rest = serve_cached(cache, &job.id, todo, &mut run, out_tx).await?;
+        if rest.is_empty() {
+            continue;
+        }
+        stream_path_chunks(cache, job, &info.store_path, rest, &mut run, out_tx).await?;
     }
     run.flush(&job.id, out_tx).await?;
     tracing::debug!(
@@ -185,6 +189,37 @@ async fn compute_recipe(cache: Option<&ChunkCache>, store_path: &str) -> Result<
         c.store_recipe(store_path.to_string(), recipe.clone());
     }
     Ok(recipe)
+}
+
+/// Serve needed chunks from the cache, returning what still needs a repack.
+async fn serve_cached(
+    cache: Option<&ChunkCache>,
+    build_id: &str,
+    todo: HashSet<Hash>,
+    run: &mut RunFrames,
+    out_tx: &mpsc::Sender<Result<HubMessage, Status>>,
+) -> Result<HashSet<Hash>> {
+    let Some(frames) = cache.and_then(|c| c.locate_all(&todo)) else {
+        return Ok(todo);
+    };
+    let mut rest = todo;
+    run.flush(build_id, out_tx).await?;
+    for (hash, fref) in frames {
+        // Evicted between locate and read: the repack picks it up.
+        let Ok(frame) = fref.read() else { break };
+        send(
+            out_tx,
+            hub_message::Msg::ChunkRun(ChunkRun {
+                build_id: build_id.to_string(),
+                hashes: hash.to_vec(),
+                zstd_data: frame,
+                eof: false,
+            }),
+        )
+        .await?;
+        rest.remove(&hash);
+    }
+    Ok(rest)
 }
 
 /// Re-pack the path and route its needed chunks: cache hits as their
@@ -326,5 +361,47 @@ impl RunFrames {
     ) -> Result<()> {
         self.rotate(build_id, out_tx).await?;
         self.drain(build_id, out_tx).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn serve_cached_skips_repack_and_reports_leftovers() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = ChunkCache::open(dir.path().to_path_buf(), 1 << 20).unwrap();
+        let a: Hash = [1; 32];
+        let b: Hash = [2; 32];
+        cache.admit(a, &zstd::bulk::compress(b"hello", 3).unwrap());
+
+        let (tx, mut rx) = mpsc::channel(8);
+        let mut run = RunFrames::default();
+
+        let todo: HashSet<Hash> = [a, b].into();
+        let rest = serve_cached(Some(&cache), "b1", todo.clone(), &mut run, &tx)
+            .await
+            .unwrap();
+        assert_eq!(rest, todo);
+
+        let rest = serve_cached(Some(&cache), "b1", [a].into(), &mut run, &tx)
+            .await
+            .unwrap();
+        assert!(rest.is_empty());
+        let msg = rx.recv().await.unwrap().unwrap();
+        let Some(hub_message::Msg::ChunkRun(cr)) = msg.msg else {
+            panic!("expected ChunkRun");
+        };
+        assert_eq!(cr.hashes, a.to_vec());
+        assert_eq!(
+            zstd::bulk::decompress(&cr.zstd_data, 1 << 20).unwrap(),
+            b"hello"
+        );
+
+        let rest = serve_cached(None, "b1", [a].into(), &mut run, &tx)
+            .await
+            .unwrap();
+        assert_eq!(rest, [a].into());
     }
 }

--- a/crates/tribuchet/src/main.rs
+++ b/crates/tribuchet/src/main.rs
@@ -20,6 +20,7 @@ mod tailscale;
 mod tmpdir;
 mod worker;
 
+#[cfg(target_os = "linux")]
 use std::env;
 use std::path::PathBuf;
 use std::process::ExitCode;

--- a/crates/tribuchet/src/rt.rs
+++ b/crates/tribuchet/src/rt.rs
@@ -1,6 +1,7 @@
 //! Shared tokio runtime construction and thread naming, so a profile or
 //! `top -H` can tell which role (and which kind of work) a thread runs.
 
+#[cfg(target_os = "linux")]
 use std::ffi::CString;
 use std::io;
 

--- a/crates/tribuchet/src/worker/agent.rs
+++ b/crates/tribuchet/src/worker/agent.rs
@@ -11,8 +11,6 @@
 //! crates/sandbox-proto/proto/agent.proto.
 
 use std::collections::HashMap;
-#[cfg(target_os = "macos")]
-use std::ffi::NulError;
 use std::fs;
 use std::io::{Read, Write};
 use std::os::fd::OwnedFd;

--- a/crates/tribuchet/src/worker/sandbox.rs
+++ b/crates/tribuchet/src/worker/sandbox.rs
@@ -18,6 +18,7 @@ use std::fs;
 use std::io;
 #[cfg(target_os = "linux")]
 use std::os::fd::OwnedFd;
+#[cfg(target_os = "linux")]
 use std::os::unix::process::CommandExt;
 #[cfg(target_os = "linux")]
 use std::path::Path;
@@ -31,6 +32,7 @@ use rustix::pipe::{PipeFlags, pipe_with};
 
 #[cfg(target_os = "linux")]
 use super::binfmt;
+#[cfg(target_os = "linux")]
 use crate::fsutil::io_ctx;
 use crate::netpolicy::NetPolicy;
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
stream_path_chunks re-packs the NAR even when every needed chunk is
already in the chunk store, so staging fan-out paid CDC and BLAKE3
twice per path. A live hub profile showed 16% of CPU in that repack.
Walk the recipe first and ship stored frames directly, falling back
to the repack only for chunks the store lacks or evicts mid-serve.
