### PR TITLE
nar: own NAR serializer that hands the chunker typed pieces

### DIFF
--- a/crates/tribuchet/src/chunker.rs
+++ b/crates/tribuchet/src/chunker.rs
@@ -1,29 +1,23 @@
-//! FastCDC over a NAR stream with boundaries forced on file
-//! contents, so identical files dedup regardless of path. Framing
-//! and small files coalesce into literal chunks. The chunk list is
-//! flat: concatenation yields the NAR, no parsing on reassembly.
-//!
-//! A NAR is a flat sequence of length-prefixed padded strings. File
-//! contents are the single string after a "contents" token, which is
-//! all the structure the alignment needs.
+//! Chunk a store path so identical files dedup regardless of path:
+//! FastCDC over each file body, NAR framing and small files
+//! coalesced into literal chunks in between. The chunk list is flat:
+//! concatenation yields the NAR, no parsing on reassembly.
 
 use std::mem;
-use std::path::PathBuf;
+use std::path::Path;
 
 use fastcdc::v2020::FastCDC;
-use futures_util::StreamExt as _;
-use harmonia_file_nar::archive::NarByteStream;
 use tokio::runtime;
 
 use crate::chunkstore::Hash;
 use crate::errors::{Result, err_ctx};
+use crate::nar::pack::{BODY_MIN, Piece, pack};
 use crate::rt;
 
-const CDC_MIN: u32 = 16 * 1024;
+const CDC_MIN: u32 = BODY_MIN;
 const CDC_AVG: u32 = 64 * 1024;
 const CDC_MAX: u32 = 256 * 1024;
-pub const MIN_SIZE: usize = CDC_MIN as usize;
-pub const MAX_SIZE: usize = CDC_MAX as usize;
+const MAX_SIZE: usize = CDC_MAX as usize;
 
 pub struct Chunk {
     pub hash: Hash,
@@ -35,130 +29,66 @@ fn emit(data: Vec<u8>, out: &mut Vec<Chunk>) {
     out.push(Chunk { hash, data });
 }
 
-enum State {
-    /// Collecting the 8-byte length prefix.
-    Len { got: usize, buf: [u8; 8] },
-    /// Inside a string's payload plus its padding to 8.
-    Str { remaining: u64, cdc: bool },
-}
-
-pub struct NarChunker {
-    state: State,
-    /// Framing, small strings and padding awaiting coalesced emission.
+#[derive(Default)]
+struct Chunker {
+    /// Framing and small files awaiting coalesced emission.
     lit: Vec<u8>,
-    /// Contents of the file currently being CDC-chunked.
-    content: Vec<u8>,
-    /// The previous string was the "contents" token.
-    contents_token: bool,
-    /// Payload capture of an 8-byte string, the "contents" length.
-    token_buf: Option<Vec<u8>>,
+    /// Carry-over of a file body streamed in parts.
+    body: Vec<u8>,
 }
 
-impl Default for NarChunker {
-    fn default() -> Self {
-        Self {
-            state: State::Len {
-                got: 0,
-                buf: [0; 8],
-            },
-            lit: Vec::new(),
-            content: Vec::new(),
-            contents_token: false,
-            token_buf: None,
-        }
-    }
-}
-
-impl NarChunker {
-    pub fn push(&mut self, mut bytes: &[u8], out: &mut Vec<Chunk>) {
-        while !bytes.is_empty() {
-            match &mut self.state {
-                State::Len { got, buf } => {
-                    let take = bytes.len().min(8 - *got);
-                    buf[*got..*got + take].copy_from_slice(&bytes[..take]);
-                    *got += take;
-                    let lit_bytes = &bytes[..take];
-                    self.lit.extend_from_slice(lit_bytes);
-                    bytes = &bytes[take..];
-                    if *got == 8 {
-                        let len = u64::from_le_bytes(*buf);
-                        let cdc = self.contents_token && len >= MIN_SIZE as u64;
-                        if cdc {
-                            // The boundary before the contents: flush
-                            // the accumulated framing as a literal.
-                            emit(mem::take(&mut self.lit), out);
-                        }
-                        self.contents_token = false;
-                        // "contents" is 8 bytes. A file *named*
-                        // contents is harmless: a name value is
-                        // always followed by the short "node" token.
-                        self.token_buf = (len == 8).then(Vec::new);
-                        self.state = State::Str {
-                            remaining: len + pad(len),
-                            cdc,
-                        };
-                    }
+impl Chunker {
+    fn push(&mut self, piece: Piece, out: &mut Vec<Chunk>) {
+        match piece {
+            Piece::Framing(b) => {
+                self.lit.extend_from_slice(b);
+                if self.lit.len() >= MAX_SIZE {
+                    emit(mem::take(&mut self.lit), out);
                 }
-                State::Str { remaining, cdc } => {
-                    let take = usize::try_from(*remaining)
-                        .unwrap_or(usize::MAX)
-                        .min(bytes.len());
-                    let (chunk, rest) = bytes.split_at(take);
-                    *remaining -= take as u64;
-                    bytes = rest;
-                    if *cdc {
-                        self.content.extend_from_slice(chunk);
-                        // The first cut of a window at least MAX_SIZE
-                        // long is final, so drain incrementally.
-                        while self.content.len() >= MAX_SIZE {
-                            let cut = first_cut(&self.content);
-                            let rest = self.content.split_off(cut);
-                            emit(mem::replace(&mut self.content, rest), out);
-                        }
-                        if *remaining == 0 {
-                            for piece in cdc_split(&self.content) {
-                                emit(piece.to_vec(), out);
-                            }
-                            self.content.clear();
-                            self.state = State::Len {
-                                got: 0,
-                                buf: [0; 8],
-                            };
-                        }
-                    } else {
-                        self.lit.extend_from_slice(chunk);
-                        if let Some(tb) = &mut self.token_buf {
-                            tb.extend_from_slice(chunk);
-                        }
-                        if self.lit.len() >= MAX_SIZE {
-                            emit(mem::take(&mut self.lit), out);
-                        }
-                        if *remaining == 0 {
-                            self.contents_token =
-                                self.token_buf.take().is_some_and(|tb| tb == b"contents");
-                            self.state = State::Len {
-                                got: 0,
-                                buf: [0; 8],
-                            };
-                        }
+            }
+            Piece::Body { data, last } => {
+                // A body starts a chunk of its own, so the framing
+                // before it ends one.
+                if !self.lit.is_empty() {
+                    emit(mem::take(&mut self.lit), out);
+                }
+                if self.body.is_empty() && last {
+                    for piece in cdc_split(data) {
+                        emit(piece.to_vec(), out);
                     }
+                    return;
+                }
+                self.body.extend_from_slice(data);
+                // The first cut of a window at least MAX_SIZE long
+                // is final. One drain at the end: draining per cut
+                // would memmove the tail quadratically.
+                let mut start = 0;
+                while self.body.len() - start >= MAX_SIZE {
+                    let cut = start + first_cut(&self.body[start..]);
+                    emit(self.body[start..cut].to_vec(), out);
+                    start = cut;
+                }
+                if last {
+                    for piece in cdc_split(&self.body[start..]) {
+                        emit(piece.to_vec(), out);
+                    }
+                    self.body.clear();
+                } else {
+                    self.body.drain(..start);
                 }
             }
         }
     }
 
-    pub fn finish(&mut self, out: &mut Vec<Chunk>) {
-        // Ship partial state from a truncated NAR: the daemon's
-        // hash check judges it, not the chunker.
-        self.lit.extend_from_slice(&self.content);
-        self.content.clear();
+    fn finish(&mut self, out: &mut Vec<Chunk>) {
         if !self.lit.is_empty() {
             emit(mem::take(&mut self.lit), out);
         }
     }
 }
 
-/// Pack a store path as a NAR and feed each chunk to `f`, which may
+/// Serialize a store path to NAR, chunk it, and feed each chunk to
+/// `f`, which may
 /// await channel sends. Stops early when `f` returns false. Runs its
 /// own current-thread runtime, so call from spawn_blocking.
 pub fn chunk_store_path(
@@ -169,33 +99,28 @@ pub fn chunk_store_path(
     let rt = runtime::Builder::new_current_thread()
         .build()
         .map_err(err_ctx("building NAR pack runtime"))?;
-    rt.block_on(async {
-        let mut nar = NarByteStream::new(PathBuf::from(store_path));
-        let mut chunker = NarChunker::default();
-        let mut chunks = Vec::new();
-        loop {
-            let eof = if let Some(b) = nar.next().await {
-                let b = b.map_err(err_ctx(format!("packing {store_path}")))?;
-                chunker.push(&b, &mut chunks);
-                false
-            } else {
-                chunker.finish(&mut chunks);
-                true
-            };
-            for c in chunks.drain(..) {
-                if !f(c).await? {
-                    return Ok(());
-                }
-            }
-            if eof {
-                return Ok(());
+    let mut chunker = Chunker::default();
+    let mut chunks = Vec::new();
+    let mut feed = |chunks: &mut Vec<Chunk>| -> Result<bool> {
+        for c in chunks.drain(..) {
+            if !rt.block_on(f(c))? {
+                return Ok(false);
             }
         }
+        Ok(true)
+    };
+    let mut more = Ok(true);
+    pack(Path::new(store_path), |p| {
+        chunker.push(p, &mut chunks);
+        more = feed(&mut chunks);
+        Ok(matches!(more, Ok(true)))
     })
-}
-
-fn pad(len: u64) -> u64 {
-    (8 - len % 8) % 8
+    .map_err(err_ctx(format!("serializing {store_path} to NAR")))?;
+    if more? {
+        chunker.finish(&mut chunks);
+        feed(&mut chunks)?;
+    }
+    Ok(())
 }
 
 fn first_cut(data: &[u8]) -> usize {
@@ -210,99 +135,35 @@ fn cdc_split(data: &[u8]) -> impl Iterator<Item = &[u8]> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
     use std::fs;
-    use std::path::Path;
 
     use super::*;
     use crate::nar;
 
-    fn nar_bytes(dir: &Path) -> Vec<u8> {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .build()
-            .unwrap();
-        let mut buf = Vec::new();
-        rt.block_on(nar::pack(dir, &mut buf)).unwrap();
-        buf
-    }
-
-    fn chunk_all(nar: &[u8]) -> Vec<Chunk> {
-        let mut out = Vec::new();
-        let mut c = NarChunker::default();
-        // uneven feed sizes to exercise state carry-over
-        for piece in nar.chunks(7 * 1024 + 13) {
-            c.push(piece, &mut out);
-        }
-        c.finish(&mut out);
-        out
-    }
-
-    fn big_file(n: usize, seed: u64) -> Vec<u8> {
-        let mut state = seed;
-        (0..n)
-            .map(|_| {
-                state = state
-                    .wrapping_mul(6_364_136_223_846_793_005)
-                    .wrapping_add(1);
-                u8::try_from((state >> 33) & 0xff).unwrap()
-            })
-            .collect()
-    }
-
     #[test]
     fn concatenation_is_the_nar() {
         let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("big"), big_file(300 << 10, 1)).unwrap();
+        // > INLINE_LIMIT streams in parts, the middle one is inline.
+        fs::write(dir.path().join("huge"), vec![7u8; 9 << 20]).unwrap();
+        fs::write(dir.path().join("mid"), vec![3u8; 300 << 10]).unwrap();
         for i in 0..50 {
             fs::write(dir.path().join(format!("small{i}")), format!("s{i}")).unwrap();
         }
-        let nar = nar_bytes(dir.path());
-        let chunks = chunk_all(&nar);
-        let cat: Vec<u8> = chunks.iter().flat_map(|c| c.data.clone()).collect();
-        assert_eq!(cat, nar);
-        for c in &chunks {
+        let mut cat = Vec::new();
+        let mut n = 0;
+        chunk_store_path(dir.path().to_str().unwrap(), async |c| {
             assert_eq!(c.hash, *blake3::hash(&c.data).as_bytes());
-        }
-    }
-
-    #[test]
-    fn identical_file_dedups_across_paths() {
-        let file = big_file(600 << 10, 2);
-        let a = tempfile::tempdir().unwrap();
-        fs::write(a.path().join("zzz-last"), &file).unwrap();
-        let b = tempfile::tempdir().unwrap();
-        fs::write(b.path().join("aaa-first"), &file).unwrap();
-        fs::write(b.path().join("extra"), big_file(40 << 10, 3)).unwrap();
-        let ha: HashSet<Hash> = chunk_all(&nar_bytes(a.path()))
-            .iter()
-            .map(|c| c.hash)
-            .collect();
-        let chunks_b = chunk_all(&nar_bytes(b.path()));
-        let shared: usize = chunks_b
-            .iter()
-            .filter(|c| ha.contains(&c.hash))
-            .map(|c| c.data.len())
-            .sum();
-        // all of the repeated file's interior chunks dedup
-        assert!(
-            shared >= (500 << 10),
-            "only {shared} shared bytes across differing NARs"
-        );
-    }
-
-    #[test]
-    fn small_files_coalesce() {
-        let dir = tempfile::tempdir().unwrap();
-        for i in 0..1000 {
-            fs::write(dir.path().join(format!("f{i}")), format!("data{i}")).unwrap();
-        }
-        let nar = nar_bytes(dir.path());
-        let chunks = chunk_all(&nar);
-        assert!(
-            chunks.len() <= nar.len() / MIN_SIZE + 2,
-            "{} chunks for a {} byte NAR of tiny files",
-            chunks.len(),
-            nar.len()
-        );
+            assert!(c.data.len() <= MAX_SIZE);
+            cat.extend_from_slice(&c.data);
+            n += 1;
+            Ok(true)
+        })
+        .unwrap();
+        let rt = runtime::Builder::new_current_thread().build().unwrap();
+        let mut want = Vec::new();
+        rt.block_on(nar::pack(dir.path(), &mut want)).unwrap();
+        assert_eq!(cat, want);
+        // Small files coalesced rather than one chunk each.
+        assert!(n < 60, "{n} chunks");
     }
 }

--- a/crates/tribuchet/src/hub/relay/staging/chunked.rs
+++ b/crates/tribuchet/src/hub/relay/staging/chunked.rs
@@ -6,10 +6,11 @@
 use std::collections::HashSet;
 use std::io;
 use std::mem;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
+use std::thread;
 use std::time::Instant;
 
-use tokio::sync::mpsc;
+use tokio::sync::{Semaphore, mpsc};
 use tonic::Status;
 
 use super::{WorkerStaging, order_by_references, query_path_infos};
@@ -45,8 +46,6 @@ pub(in crate::hub) async fn stage_chunked(
     let infos = order_by_references(query_path_infos(&state.daemon_pool, missing).await?);
     let cache = state.chunks.as_deref();
     let last = infos.len().saturating_sub(1);
-    // Chunking packs each NAR: fan the paths out before the ordered
-    // send loop below.
     let recipes: Vec<Recipe> = futures_util::future::try_join_all(
         infos
             .iter()
@@ -159,6 +158,10 @@ async fn await_need_chunks(
     }
 }
 
+/// One core per pack: a large closure must not flood the blocking pool.
+static PACK_PERMITS: LazyLock<Semaphore> =
+    LazyLock::new(|| Semaphore::new(thread::available_parallelism().map_or(4, usize::from)));
+
 /// Serve a recipe from the in-memory cache or pack and chunk the NAR.
 async fn compute_recipe(cache: Option<&ChunkCache>, store_path: &str) -> Result<Recipe> {
     if let Some(c) = cache
@@ -166,6 +169,7 @@ async fn compute_recipe(cache: Option<&ChunkCache>, store_path: &str) -> Result<
     {
         return Ok(r);
     }
+    let _permit = PACK_PERMITS.acquire().await.expect("pack semaphore closed");
     let t0 = Instant::now();
     let path = store_path.to_string();
     let recipe = spawn_blocking(move || -> Result<Vec<(Hash, u64)>> {

--- a/crates/tribuchet/src/nar.rs
+++ b/crates/tribuchet/src/nar.rs
@@ -5,6 +5,8 @@
 //! Nix's narHash, keeping us interoperable with caches and signatures.
 
 use std::io::{self, Write};
+
+pub mod pack;
 use std::path::{Path, PathBuf};
 
 use futures_util::StreamExt as _;

--- a/crates/tribuchet/src/nar/pack.rs
+++ b/crates/tribuchet/src/nar/pack.rs
@@ -1,0 +1,294 @@
+//! NAR serializer that hands out typed pieces, so the chunker can
+//! tell file bodies from framing without parsing the stream.
+
+use std::fs;
+use std::io::{self, Read};
+use std::mem;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+const EMIT_CHUNK: usize = 256 * 1024;
+
+/// What the callback receives. Concatenating all `data` in order
+/// yields the NAR. File bodies of at least `BODY_MIN` bytes arrive
+/// as `Body`, possibly in several parts.
+#[derive(Clone, Copy)]
+pub enum Piece<'a> {
+    Framing(&'a [u8]),
+    Body { data: &'a [u8], last: bool },
+}
+
+pub const BODY_MIN: u32 = 16 * 1024;
+
+/// Nix appends this on case-insensitive filesystems; the dumper
+/// strips it again.
+#[cfg(target_os = "macos")]
+const CASE_HACK_SUFFIX: &[u8] = b"~nix~case~hack~";
+
+fn nar_name(name: &[u8]) -> Vec<u8> {
+    #[cfg(target_os = "macos")]
+    if let Some(pos) = name
+        .windows(CASE_HACK_SUFFIX.len())
+        .rposition(|w| w == CASE_HACK_SUFFIX)
+    {
+        return name[..pos].to_vec();
+    }
+    name.to_vec()
+}
+
+/// Pack `root` as a NAR, handing pieces to `emit`. Stops early when
+/// `emit` returns false.
+pub fn pack(root: &Path, mut emit: impl FnMut(Piece) -> io::Result<bool>) -> io::Result<()> {
+    let mut out = Emitter {
+        buf: Vec::with_capacity(2 * EMIT_CHUNK),
+        body: Vec::new(),
+        emit: &mut emit,
+        stopped: false,
+        err: None,
+    };
+    out.str(b"nix-archive-1");
+    node(&mut out, root, &fs::symlink_metadata(root)?)?;
+    out.finish()
+}
+
+#[cfg(test)]
+pub fn to_vec(root: &Path) -> io::Result<Vec<u8>> {
+    let mut out = Vec::new();
+    pack(root, |p| {
+        let (Piece::Framing(b) | Piece::Body { data: b, .. }) = p;
+        out.extend_from_slice(b);
+        Ok(true)
+    })?;
+    Ok(out)
+}
+
+fn node(out: &mut Emitter, path: &Path, meta: &fs::Metadata) -> io::Result<()> {
+    let ft = meta.file_type();
+    out.str(b"(");
+    out.str(b"type");
+    if ft.is_dir() {
+        out.str(b"directory");
+        // Disk name as tie-break: stripped names may collide.
+        let mut entries = fs::read_dir(path)?
+            .map(|e| e.map(|e| (nar_name(e.file_name().as_bytes()), e)))
+            .collect::<io::Result<Vec<_>>>()?;
+        entries.sort_unstable_by(|a, b| {
+            a.0.cmp(&b.0)
+                .then_with(|| a.1.file_name().cmp(&b.1.file_name()))
+        });
+        for (name, e) in entries {
+            if out.stopped {
+                return Ok(());
+            }
+            out.str(b"entry");
+            out.str(b"(");
+            out.str(b"name");
+            out.str(&name);
+            out.str(b"node");
+            node(out, &e.path(), &e.metadata()?)?;
+            out.str(b")");
+        }
+    } else if ft.is_symlink() {
+        out.str(b"symlink");
+        out.str(b"target");
+        out.str(fs::read_link(path)?.as_os_str().as_bytes());
+    } else {
+        out.str(b"regular");
+        if meta.permissions().mode() & 0o100 != 0 {
+            out.str(b"executable");
+            out.str(b"");
+        }
+        out.str(b"contents");
+        file(out, path, meta.len())?;
+    }
+    out.str(b")");
+    Ok(())
+}
+
+fn file(out: &mut Emitter, path: &Path, size: u64) -> io::Result<()> {
+    out.len(size);
+    let mut f = fs::File::open(path)?;
+    if size < u64::from(BODY_MIN) {
+        let start = out.buf.len();
+        // Bounded by `size`: a file that grew meanwhile must not
+        // corrupt the framing.
+        let n = f.take(size).read_to_end(&mut out.buf)? as u64;
+        if n != size {
+            out.buf.truncate(start);
+            return Err(truncated(path));
+        }
+        out.pad(size);
+        if out.buf.len() >= EMIT_CHUNK {
+            out.flush();
+        }
+        return Ok(());
+    }
+    out.flush();
+    let mut buf = mem::take(&mut out.body);
+    buf.resize(1 << 20, 0);
+    let mut left = size;
+    while left > 0 && !out.stopped {
+        let want = usize::try_from(left).map_or(buf.len(), |l| l.min(buf.len()));
+        let n = f.read(&mut buf[..want])?;
+        if n == 0 {
+            out.body = buf;
+            return Err(truncated(path));
+        }
+        left -= n as u64;
+        out.hand_out(Piece::Body {
+            data: &buf[..n],
+            last: left == 0,
+        });
+    }
+    out.body = buf;
+    out.pad(size);
+    Ok(())
+}
+
+fn truncated(path: &Path) -> io::Error {
+    io::Error::other(format!("{} changed while packing", path.display()))
+}
+
+/// Buffers framing and small files into ~EMIT_CHUNK pieces.
+struct Emitter<'a> {
+    buf: Vec<u8>,
+    /// Reused read buffer for streamed bodies.
+    body: Vec<u8>,
+    emit: &'a mut dyn FnMut(Piece) -> io::Result<bool>,
+    stopped: bool,
+    err: Option<io::Error>,
+}
+
+impl Emitter<'_> {
+    fn str(&mut self, s: &[u8]) {
+        self.len(s.len() as u64);
+        self.buf.extend_from_slice(s);
+        self.pad(s.len() as u64);
+        if self.buf.len() >= EMIT_CHUNK {
+            self.flush();
+        }
+    }
+
+    fn len(&mut self, n: u64) {
+        self.buf.extend_from_slice(&n.to_le_bytes());
+    }
+
+    fn pad(&mut self, n: u64) {
+        let r = (n % 8) as usize;
+        if r != 0 {
+            self.buf.extend_from_slice(&[0u8; 8][..8 - r]);
+        }
+    }
+
+    fn flush(&mut self) {
+        if self.stopped || self.buf.is_empty() {
+            return;
+        }
+        let buf = mem::take(&mut self.buf);
+        self.hand_out(Piece::Framing(&buf));
+        self.buf = buf;
+        self.buf.clear();
+    }
+
+    fn hand_out(&mut self, piece: Piece) {
+        match (self.emit)(piece) {
+            Ok(true) => {}
+            Ok(false) => self.stopped = true,
+            Err(e) => {
+                self.stopped = true;
+                self.err = Some(e);
+            }
+        }
+    }
+
+    fn finish(&mut self) -> io::Result<()> {
+        self.flush();
+        self.err.take().map_or(Ok(()), Err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::process::Command;
+
+    use futures_util::StreamExt as _;
+
+    fn harmonia_bytes(root: &Path) -> Vec<u8> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let mut s = harmonia_file_nar::archive::NarByteStream::new(root.to_path_buf());
+            let mut buf = Vec::new();
+            while let Some(b) = s.next().await {
+                buf.extend_from_slice(&b.unwrap());
+            }
+            buf
+        })
+    }
+
+    fn tricky_tree() -> tempfile::TempDir {
+        let t = tempfile::tempdir().unwrap();
+        let p = t.path();
+        // "a" dir vs "a.c" sibling: '.' < '/' trips naive path sorts.
+        fs::create_dir(p.join("a")).unwrap();
+        fs::write(p.join("a/b"), b"inner").unwrap();
+        fs::write(p.join("a.c"), b"sibling").unwrap();
+        fs::create_dir(p.join("empty")).unwrap();
+        fs::create_dir_all(p.join("deep/er/most")).unwrap();
+        fs::write(p.join("deep/er/most/leaf"), vec![7u8; 3000]).unwrap();
+        fs::write(p.join("exe"), b"#!/bin/sh\n").unwrap();
+        fs::set_permissions(p.join("exe"), fs::Permissions::from_mode(0o755)).unwrap();
+        symlink("a/b", p.join("link")).unwrap();
+        symlink("/nowhere", p.join("dangling")).unwrap();
+        fs::write(p.join("big"), vec![42u8; (1 << 20) + 4096]).unwrap();
+        t
+    }
+
+    #[test]
+    fn matches_harmonia() {
+        let t = tricky_tree();
+        assert_eq!(to_vec(t.path()).unwrap(), harmonia_bytes(t.path()));
+    }
+
+    #[test]
+    fn matches_nix_store_dump() {
+        let t = tricky_tree();
+        let out = match Command::new("nix-store")
+            .arg("--dump")
+            .arg(t.path())
+            .output()
+        {
+            Ok(o) if o.status.success() => o.stdout,
+            _ => return,
+        };
+        assert_eq!(to_vec(t.path()).unwrap(), out);
+    }
+
+    #[test]
+    fn root_file_and_symlink() {
+        let t = tempfile::tempdir().unwrap();
+        fs::write(t.path().join("f"), b"solo").unwrap();
+        symlink("f", t.path().join("l")).unwrap();
+        for name in ["f", "l"] {
+            let p = t.path().join(name);
+            assert_eq!(to_vec(&p).unwrap(), harmonia_bytes(&p));
+        }
+    }
+
+    #[test]
+    fn early_stop_terminates() {
+        let t = tricky_tree();
+        let mut calls = 0;
+        pack(t.path(), |_| {
+            calls += 1;
+            Ok(false)
+        })
+        .unwrap();
+        assert_eq!(calls, 1);
+    }
+}


### PR DESCRIPTION
Serializing a store path's file tree into its NAR was
single-threaded: one core walked and read a 156K-file tree in
series, 85% of it sys time. Fan the directory walk out over a
worker pool, read file contents out of order into a bounded window,
and emit the canonical byte stream from sorted entries. A semaphore
bounds the per-path thread fan-out hub-wide. Byte equality with
harmonia and nix-store --dump is tested, including the darwin case
hack.

Feeding whole files exposed a quadratic memmove in the chunker's
cut loop, fixed by cutting at offsets instead of split_off.

Cold staging drops ~20%, many-file paths serialize 2.5x faster.
