### PR TITLE
bump nixpkgs, harmonia and fastcdc 5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,9 +563,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastcdc"
-version = "4.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af40d8a8dadb92dc178569a5f5edb5f3056e98255c2de48ab5d59a52892e0c"
+checksum = "0431c3132902a1bed6fe77dcfa5d03844e083f263b81288246a2d43dd7d4b2ad"
 
 [[package]]
 name = "fastrand"
@@ -704,8 +704,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-file-core"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=d5201ff458c273438901d9a61ca2d659946e67f8#d5201ff458c273438901d9a61ca2d659946e67f8"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia?rev=10a2228f94956fb568dfc799a1c918484bf33653#10a2228f94956fb568dfc799a1c918484bf33653"
 dependencies = [
  "serde",
  "serde_json",
@@ -714,8 +714,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-file-nar"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=d5201ff458c273438901d9a61ca2d659946e67f8#d5201ff458c273438901d9a61ca2d659946e67f8"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia?rev=10a2228f94956fb568dfc799a1c918484bf33653#10a2228f94956fb568dfc799a1c918484bf33653"
 dependencies = [
  "bstr",
  "bytes",
@@ -738,8 +738,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-protocol"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=d5201ff458c273438901d9a61ca2d659946e67f8#d5201ff458c273438901d9a61ca2d659946e67f8"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia?rev=10a2228f94956fb568dfc799a1c918484bf33653#10a2228f94956fb568dfc799a1c918484bf33653"
 dependencies = [
  "async-stream",
  "bstr",
@@ -772,18 +772,18 @@ dependencies = [
 
 [[package]]
 name = "harmonia-protocol-derive"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=d5201ff458c273438901d9a61ca2d659946e67f8#d5201ff458c273438901d9a61ca2d659946e67f8"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia?rev=10a2228f94956fb568dfc799a1c918484bf33653#10a2228f94956fb568dfc799a1c918484bf33653"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "harmonia-store-aterm"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia?rev=d5201ff458c273438901d9a61ca2d659946e67f8#d5201ff458c273438901d9a61ca2d659946e67f8"
+source = "git+https://github.com/nix-community/harmonia?rev=10a2228f94956fb568dfc799a1c918484bf33653#10a2228f94956fb568dfc799a1c918484bf33653"
 dependencies = [
  "bytes",
  "harmonia-store-content-address",
@@ -798,8 +798,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-store-build-result"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=d5201ff458c273438901d9a61ca2d659946e67f8#d5201ff458c273438901d9a61ca2d659946e67f8"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia?rev=10a2228f94956fb568dfc799a1c918484bf33653#10a2228f94956fb568dfc799a1c918484bf33653"
 dependencies = [
  "harmonia-store-derivation",
  "num_enum",
@@ -809,8 +809,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-store-content-address"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=d5201ff458c273438901d9a61ca2d659946e67f8#d5201ff458c273438901d9a61ca2d659946e67f8"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia?rev=10a2228f94956fb568dfc799a1c918484bf33653#10a2228f94956fb568dfc799a1c918484bf33653"
 dependencies = [
  "derive_more",
  "harmonia-store-path",
@@ -821,9 +821,10 @@ dependencies = [
 
 [[package]]
 name = "harmonia-store-db"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=d5201ff458c273438901d9a61ca2d659946e67f8#d5201ff458c273438901d9a61ca2d659946e67f8"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia?rev=10a2228f94956fb568dfc799a1c918484bf33653#10a2228f94956fb568dfc799a1c918484bf33653"
 dependencies = [
+ "foldhash 0.2.0",
  "harmonia-store-content-address",
  "harmonia-store-derivation",
  "harmonia-store-path",
@@ -838,7 +839,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-derivation"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia?rev=d5201ff458c273438901d9a61ca2d659946e67f8#d5201ff458c273438901d9a61ca2d659946e67f8"
+source = "git+https://github.com/nix-community/harmonia?rev=10a2228f94956fb568dfc799a1c918484bf33653#10a2228f94956fb568dfc799a1c918484bf33653"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -856,8 +857,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-store-path"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=d5201ff458c273438901d9a61ca2d659946e67f8#d5201ff458c273438901d9a61ca2d659946e67f8"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia?rev=10a2228f94956fb568dfc799a1c918484bf33653#10a2228f94956fb568dfc799a1c918484bf33653"
 dependencies = [
  "derive_more",
  "harmonia-utils-base-encoding",
@@ -869,8 +870,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-store-path-info"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=d5201ff458c273438901d9a61ca2d659946e67f8#d5201ff458c273438901d9a61ca2d659946e67f8"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia?rev=10a2228f94956fb568dfc799a1c918484bf33653#10a2228f94956fb568dfc799a1c918484bf33653"
 dependencies = [
  "harmonia-store-content-address",
  "harmonia-store-path",
@@ -882,7 +883,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-ref-scan"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia?rev=d5201ff458c273438901d9a61ca2d659946e67f8#d5201ff458c273438901d9a61ca2d659946e67f8"
+source = "git+https://github.com/nix-community/harmonia?rev=10a2228f94956fb568dfc799a1c918484bf33653#10a2228f94956fb568dfc799a1c918484bf33653"
 dependencies = [
  "harmonia-store-path",
  "harmonia-utils-base-encoding",
@@ -890,8 +891,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-store-remote"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=d5201ff458c273438901d9a61ca2d659946e67f8#d5201ff458c273438901d9a61ca2d659946e67f8"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia?rev=10a2228f94956fb568dfc799a1c918484bf33653#10a2228f94956fb568dfc799a1c918484bf33653"
 dependencies = [
  "async-stream",
  "futures-core",
@@ -911,7 +912,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-base-encoding"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia?rev=d5201ff458c273438901d9a61ca2d659946e67f8#d5201ff458c273438901d9a61ca2d659946e67f8"
+source = "git+https://github.com/nix-community/harmonia?rev=10a2228f94956fb568dfc799a1c918484bf33653#10a2228f94956fb568dfc799a1c918484bf33653"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -921,7 +922,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-hash"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia?rev=d5201ff458c273438901d9a61ca2d659946e67f8#d5201ff458c273438901d9a61ca2d659946e67f8"
+source = "git+https://github.com/nix-community/harmonia?rev=10a2228f94956fb568dfc799a1c918484bf33653#10a2228f94956fb568dfc799a1c918484bf33653"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -933,16 +934,16 @@ dependencies = [
  "sha1",
  "sha2",
  "thiserror",
- "tokio",
 ]
 
 [[package]]
 name = "harmonia-utils-io"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia?rev=d5201ff458c273438901d9a61ca2d659946e67f8#d5201ff458c273438901d9a61ca2d659946e67f8"
+source = "git+https://github.com/nix-community/harmonia?rev=10a2228f94956fb568dfc799a1c918484bf33653#10a2228f94956fb568dfc799a1c918484bf33653"
 dependencies = [
  "bytes",
  "futures-util",
+ "harmonia-utils-hash",
  "libc",
  "nix",
  "pin-project-lite",
@@ -951,8 +952,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-utils-signature"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia?rev=d5201ff458c273438901d9a61ca2d659946e67f8#d5201ff458c273438901d9a61ca2d659946e67f8"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia?rev=10a2228f94956fb568dfc799a1c918484bf33653#10a2228f94956fb568dfc799a1c918484bf33653"
 dependencies = [
  "data-encoding",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ mod_module_files = "deny"
 clap = { version = "4", features = ["derive"] }
 hex = "0.4"
 blake3 = "1"
-fastcdc = "4"
+fastcdc = "5"
 hyper-util = "0.1"
 rustix = { version = "1", features = ["event", "fs", "mount", "net", "pipe", "process", "stdio", "system", "thread"] }
 nix = { version = "0.31", features = ["process", "user"] }
@@ -45,10 +45,10 @@ futures-util = "0.3"
 async-compression = { version = "0.4", features = ["tokio", "zstd"] }
 tokio-util = { version = "0.7", features = ["io"] }
 bytes = "1"
-harmonia-file-nar = { git = "https://github.com/nix-community/harmonia", rev = "d5201ff458c273438901d9a61ca2d659946e67f8" }
-harmonia-store-path = { git = "https://github.com/nix-community/harmonia", rev = "d5201ff458c273438901d9a61ca2d659946e67f8" }
-harmonia-store-path-info = { git = "https://github.com/nix-community/harmonia", rev = "d5201ff458c273438901d9a61ca2d659946e67f8" }
+harmonia-file-nar = { git = "https://github.com/nix-community/harmonia", rev = "10a2228f94956fb568dfc799a1c918484bf33653" }
+harmonia-store-path = { git = "https://github.com/nix-community/harmonia", rev = "10a2228f94956fb568dfc799a1c918484bf33653" }
+harmonia-store-path-info = { git = "https://github.com/nix-community/harmonia", rev = "10a2228f94956fb568dfc799a1c918484bf33653" }
 rusqlite = "0.40"
-harmonia-store-db = { git = "https://github.com/nix-community/harmonia", rev = "d5201ff458c273438901d9a61ca2d659946e67f8" }
-harmonia-store-remote = { git = "https://github.com/nix-community/harmonia", rev = "d5201ff458c273438901d9a61ca2d659946e67f8" }
-harmonia-store-ref-scan = { git = "https://github.com/nix-community/harmonia", rev = "d5201ff458c273438901d9a61ca2d659946e67f8" }
+harmonia-store-db = { git = "https://github.com/nix-community/harmonia", rev = "10a2228f94956fb568dfc799a1c918484bf33653" }
+harmonia-store-remote = { git = "https://github.com/nix-community/harmonia", rev = "10a2228f94956fb568dfc799a1c918484bf33653" }
+harmonia-store-ref-scan = { git = "https://github.com/nix-community/harmonia", rev = "10a2228f94956fb568dfc799a1c918484bf33653" }

--- a/crates/tribuchet/src/hub/state.rs
+++ b/crates/tribuchet/src/hub/state.rs
@@ -169,7 +169,11 @@ impl HubState {
             notify: Notify::default(),
             daemon_pool: harmonia_store_remote::ConnectionPool::new(
                 "/nix/var/nix/daemon-socket/socket",
-                harmonia_store_remote::PoolConfig::default(),
+                // A loaded nix-daemon can exceed the 10s default.
+                harmonia_store_remote::PoolConfig {
+                    connection_timeout: Duration::from_mins(1),
+                    ..Default::default()
+                },
             ),
             worker_caps: StdMutex::default(),
             next_worker_id: atomic::AtomicU64::default(),

--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787135253,
-        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
         "type": "github"
       },
       "original": {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -59,12 +59,12 @@ craneLib.buildPackage (
     inherit cargoArtifacts;
     passthru = { inherit cargoArtifacts e2eTests; };
   }
-  // lib.optionalAttrs stdenv.isDarwin {
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
     # sandbox_init is not permitted inside the Nix build sandbox;
     # `nix develop -c cargo test` runs it
     cargoTestExtraArgs = "-- --skip=worker::agents::tests::seatbelt_profile_confines_the_builder";
   }
-  // lib.optionalAttrs stdenv.isLinux {
+  // lib.optionalAttrs stdenv.hostPlatform.isLinux {
     # default network backend for fixed-output builds
     # static /bin/sh for the sandbox, as Nix uses for its sandbox-shell
     TRIBUCHET_BIN_SH = "${busybox-sandbox-shell}/bin/busybox";


### PR DESCRIPTION
Supersedes #119 and #120 (their CI failures were builder infra timeouts). Also bumps harmonia to 10a2228f.