### PR TITLE
flakelet: health checks for auto-updates

### DIFF
--- a/crates/tribuchet/src/sd.rs
+++ b/crates/tribuchet/src/sd.rs
@@ -179,6 +179,11 @@ pub fn notify_ready() {
     let _ = sd_notify::notify(&[sd_notify::NotifyState::Ready]);
 }
 
+/// STATUS= line shown by `systemctl status`.
+pub fn notify_status(status: &str) {
+    let _ = sd_notify::notify(&[sd_notify::NotifyState::Status(status)]);
+}
+
 /// Resolves on SIGTERM, after telling systemd shutdown started
 /// ("deactivating" in systemctl status instead of an apparently hung
 /// stop while builds drain). Never resolves if no handler can be

--- a/crates/tribuchet/src/worker.rs
+++ b/crates/tribuchet/src/worker.rs
@@ -392,7 +392,10 @@ async fn run_async(opts: WorkerConfig) -> Result<()> {
         let started = Instant::now();
         match session::session(&opts, &ctx).await {
             Ok(()) => unreachable!("session only returns on error"),
-            Err(e) => tracing::warn!("hub session ended: {e:#}"),
+            Err(e) => {
+                tracing::warn!("hub session ended: {e:#}");
+                sd::notify_status(&format!("disconnected from hub: {e:#}"));
+            }
         }
         if started.elapsed() > Duration::from_mins(1) {
             backoff = Duration::from_secs(1);

--- a/crates/tribuchet/src/worker/session.rs
+++ b/crates/tribuchet/src/worker/session.rs
@@ -23,6 +23,10 @@ use crate::proto::{
     RequestJob, Resumed, WorkerMessage, hub_message, worker_hub_client::WorkerHubClient,
     worker_message,
 };
+use crate::sd;
+
+/// nix/flakelet-worker.nix greps the unit's StatusText for this.
+pub const CONNECTED_STATUS: &str = "connected to hub";
 
 pub(super) async fn session(opts: &WorkerConfig, ctx: &Arc<WorkerCtx>) -> Result<()> {
     let mut endpoint = Endpoint::from_shared(opts.hub.clone())?;
@@ -69,6 +73,7 @@ pub(super) async fn session(opts: &WorkerConfig, ctx: &Arc<WorkerCtx>) -> Result
         .await?
         .into_inner();
     tracing::info!(hub = opts.hub, systems = ?opts.systems, "connected to hub");
+    sd::notify_status(CONNECTED_STATUS);
 
     let mut active: HashMap<String, ActiveBuild> = HashMap::new();
     let result = session_loop(

--- a/nix/flakelet-hub.nix
+++ b/nix/flakelet-hub.nix
@@ -124,5 +124,13 @@
       };
 
       exports.ports.workers = { inherit port; };
+    }
+    # The listeners are systemd's, so only the metrics endpoint proves the
+    # hub process serves; Type=notify covers startup otherwise.
+    // lib.optionalAttrs (options.hub ? "metrics-listen") {
+      healthCheck = pkgs.writeShellScript "${name}-health" ''
+        exec ${lib.getExe pkgs.curl} -sf --max-time 5 --retry 5 --retry-all-errors --retry-delay 2 \
+          -o /dev/null http://${options.hub."metrics-listen"}/metrics
+      '';
     };
 }

--- a/nix/flakelet-worker.nix
+++ b/nix/flakelet-worker.nix
@@ -54,5 +54,18 @@
       };
       services."agent@" = units.agentServiceConfig;
       services.${name} = units.workerServiceConfig;
+
+      # READY only means local setup finished; roll back a worker that
+      # never reaches the hub.
+      healthCheck = pkgs.writeShellScript "${name}-health" ''
+        for _ in $(${pkgs.coreutils}/bin/seq 30); do
+          case $(${pkgs.systemd}/bin/systemctl show -P StatusText ${name}.service) in
+            "connected to hub") exit 0 ;;
+          esac
+          ${pkgs.coreutils}/bin/sleep 2
+        done
+        echo "${name}: no hub session after 60s" >&2
+        exit 1
+      '';
     };
 }


### PR DESCRIPTION
Worker: STATUS=connected to hub via sd_notify; flakelet healthCheck waits up to 60s for it, else rollback. Hub: curl metrics endpoint when hub.metrics-listen is set.