### PR TITLE
herculesCI: deploy hub and workers via flakelet on push to main

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,6 +35,29 @@
         "type": "github"
       }
     },
+    "nixbot": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788263804,
+        "narHash": "sha256-uGJpIQ557WwPO87CvOQXCIwcWFddrc8BbLfaUt6L+N8=",
+        "owner": "Mic92",
+        "repo": "nixbot",
+        "rev": "bc373dff96945544d62d85e6ad8d3c285c34fa58",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "nixbot",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1788179007,
@@ -55,6 +78,7 @@
       "inputs": {
         "crane": "crane",
         "nix-darwin": "nix-darwin",
+        "nixbot": "nixbot",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,11 @@
     url = "github:numtide/treefmt-nix";
     inputs.nixpkgs.follows = "nixpkgs";
   };
+  inputs.nixbot = {
+    url = "github:Mic92/nixbot";
+    inputs.nixpkgs.follows = "nixpkgs";
+    inputs.treefmt-nix.follows = "treefmt-nix";
+  };
   # only used to evaluate the darwin module in checks
   inputs.nix-darwin = {
     url = "github:nix-darwin/nix-darwin";
@@ -18,6 +23,7 @@
       self,
       nixpkgs,
       crane,
+      nixbot,
       nix-darwin,
       treefmt-nix,
     }:
@@ -62,6 +68,11 @@
       darwinModules.default = import ./nix/darwin-module.nix self;
 
       nixosModules.default = import ./nix/nixos-module.nix self;
+
+      herculesCI = import ./nix/hercules-ci.nix {
+        pkgs = nixpkgs.legacyPackages.x86_64-linux;
+        effects = nixbot.lib.effects { pkgs = nixpkgs.legacyPackages.x86_64-linux; };
+      };
 
       # Run hub/worker via flakelet (https://github.com/Mic92/flakelet):
       # units update from this flake independently of the host system.

--- a/nix/hercules-ci.nix
+++ b/nix/hercules-ci.nix
@@ -1,0 +1,44 @@
+# Enqueue `flakelet update` on the hub and worker hosts, authorized by a
+# step-ca ssh certificate for this repo's main branch.
+{ pkgs, effects }:
+let
+  hosts = [
+    "eve.r"
+    "eliza.r"
+    "jamie.r"
+  ];
+in
+{ primaryRepo, ... }:
+{
+  onPush.default.outputs.effects.deploy = effects.runIf ((primaryRepo.branch or null) == "main") (
+    effects.mkEffect {
+      name = "deploy";
+      idTokenAudiences = [ "step-ca-ssh" ];
+      inputs = [
+        pkgs.step-cli
+        pkgs.openssh
+      ];
+      effectScript = ''
+        export STEPPATH=$PWD/.step
+        step ca bootstrap --ca-url https://ca.r \
+          --fingerprint 759759ea7dc7d635d761ce19a07bc0b3ab02212318e05b49d2b194c60414b84a
+
+        ssh-keygen -t ed25519 -N "" -q -f ./id_deploy
+        step ssh certificate --sign --provisioner nixbot \
+          --token "$(nixbot-id-token step-ca-ssh)" \
+          deploy ./id_deploy.pub
+
+        rc=0
+        for host in ${toString hosts}; do
+          ssh -i ./id_deploy \
+            -o CertificateFile=./id_deploy-cert.pub \
+            -o UserKnownHostsFile=$PWD/known_hosts \
+            -o StrictHostKeyChecking=accept-new \
+            -o ConnectTimeout=10 \
+            "flakelet-deploy@$host" || rc=1
+        done
+        exit $rc
+      '';
+    }
+  );
+}


### PR DESCRIPTION
ssh flakelet-deploy@{eve,eliza,jamie}.r with a step-ca cert (provisioner nixbot, principal repo:github:Mic92/tribuchet:ref:refs/heads/main); hosts map that principal to systemctl start flakelet-update@tribuchet-{hub,worker}. Needs the flakelet-deploy module deployed in dotfiles / doctor-cluster-config first.