### PR TITLE
worker-units: clear scratch as root before starting an agent

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,29 +35,6 @@
         "type": "github"
       }
     },
-    "nixbot": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "treefmt-nix": [
-          "treefmt-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1788263804,
-        "narHash": "sha256-uGJpIQ557WwPO87CvOQXCIwcWFddrc8BbLfaUt6L+N8=",
-        "owner": "Mic92",
-        "repo": "nixbot",
-        "rev": "bc373dff96945544d62d85e6ad8d3c285c34fa58",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Mic92",
-        "repo": "nixbot",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1788179007,
@@ -78,7 +55,6 @@
       "inputs": {
         "crane": "crane",
         "nix-darwin": "nix-darwin",
-        "nixbot": "nixbot",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -7,11 +7,6 @@
     url = "github:numtide/treefmt-nix";
     inputs.nixpkgs.follows = "nixpkgs";
   };
-  inputs.nixbot = {
-    url = "github:Mic92/nixbot";
-    inputs.nixpkgs.follows = "nixpkgs";
-    inputs.treefmt-nix.follows = "treefmt-nix";
-  };
   # only used to evaluate the darwin module in checks
   inputs.nix-darwin = {
     url = "github:nix-darwin/nix-darwin";
@@ -23,7 +18,6 @@
       self,
       nixpkgs,
       crane,
-      nixbot,
       nix-darwin,
       treefmt-nix,
     }:
@@ -71,7 +65,7 @@
 
       herculesCI = import ./nix/hercules-ci.nix {
         pkgs = nixpkgs.legacyPackages.x86_64-linux;
-        effects = nixbot.lib.effects { pkgs = nixpkgs.legacyPackages.x86_64-linux; };
+        effects = import ./nix/effects.nix { pkgs = nixpkgs.legacyPackages.x86_64-linux; };
       };
 
       # Run hub/worker via flakelet (https://github.com/Mic92/flakelet):

--- a/nix/effects.nix
+++ b/nix/effects.nix
@@ -1,0 +1,82 @@
+# Minimal hercules-ci-effects compatible mkEffect/runIf as understood by
+# nixbot, inlined so this flake does not depend on the nixbot flake.
+{
+  pkgs,
+  lib ? pkgs.lib,
+}:
+let
+  # Fetches a workload-identity ID token from nixbot inside the effect
+  # sandbox. Usage: nixbot-id-token <audience>
+  idTokenScript = pkgs.writeShellApplication {
+    name = "nixbot-id-token";
+    runtimeInputs = [
+      pkgs.curl
+      pkgs.jq
+    ];
+    text = ''
+      if [[ -z "''${NIXBOT_ID_TOKEN_REQUEST_URL:-}" || -z "''${NIXBOT_ID_TOKEN_REQUEST_TOKEN:-}" ]]; then
+        echo "nixbot-id-token: no ID token endpoint available; declare the audience in the effect's idTokenAudiences" >&2
+        exit 1
+      fi
+      jq -cn --arg audience "$1" '$ARGS.named' \
+        | curl -fsS --max-time 30 \
+            -H "Authorization: Bearer $NIXBOT_ID_TOKEN_REQUEST_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data-binary @- "$NIXBOT_ID_TOKEN_REQUEST_URL" \
+        | jq -re .token
+    '';
+  };
+in
+{
+  mkEffect =
+    {
+      effectScript ? "",
+      name ? "effect",
+      inputs ? [ ],
+      idTokenAudiences ? [ ],
+    }:
+    pkgs.stdenvNoCC.mkDerivation {
+      inherit name effectScript;
+      isEffect = true;
+      __hci_effect_fsroot_copy = pkgs.runCommand "mkEffect-root" { } ''
+        mkdir -p $out/bin $out/usr/bin
+        ln -s ${lib.getExe pkgs.bash} $out/bin/sh
+        ln -s ${pkgs.coreutils}/bin/env $out/usr/bin/env
+      '';
+      secretsMap = builtins.toJSON { };
+      idTokenAudiences = builtins.toJSON idTokenAudiences;
+      nativeBuildInputs = [
+        pkgs.cacert
+        pkgs.curl
+        pkgs.jq
+      ]
+      ++ lib.optional (idTokenAudiences != [ ]) idTokenScript
+      ++ inputs;
+      phases = [
+        "initPhase"
+        "effectPhase"
+      ];
+      initPhase = ''
+        exec </dev/null
+        export HOME=/build/home
+        mkdir -p "$HOME"
+        echo "root:x:$(id -u):$(id -g):root:$HOME:/bin/sh" >> /etc/passwd
+        mkdir -p ~/.ssh
+        echo "BatchMode yes" >> ~/.ssh/config
+      '';
+      effectPhase = ''eval "$effectScript"'';
+    };
+
+  # A false condition still evaluates/builds the effect's closure.
+  runIf =
+    condition: effect:
+    if condition then
+      { run = effect; }
+    else
+      {
+        dependencies = effect.inputDerivation // {
+          isEffect = false;
+          buildDependenciesOnly = true;
+        };
+      };
+}


### PR DESCRIPTION
DynamicUser may give the agent a different uid per activation, leaving the previous uid's scratch tree unremovable (EACCES).