### PR TITLE
herculesCI: deploy through flakelet-relay instead of ssh certs

### DIFF
--- a/nix/flakelet-push.nix
+++ b/nix/flakelet-push.nix
@@ -1,0 +1,23 @@
+# flakelet-push from Mic92/flakelet-relay for the deploy effect, as a
+# plain package so this flake needs no extra input.
+{
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage {
+  pname = "flakelet-push";
+  version = "0-unstable-2026-09-03";
+  src = fetchFromGitHub {
+    owner = "Mic92";
+    repo = "flakelet-relay";
+    rev = "521f8072bcdcfca712d5598a9979d5b7557eab72";
+    hash = "sha256-3fLTA1nRvw7zZilI9mEeuqOvGEW8+VeE+82K7jdhaJw=";
+  };
+  cargoHash = "sha256-gjNXc8rQZM5QKcVu/TV5RJzLdhC8XVhtRICrq1ZtK+A=";
+  cargoBuildFlags = [
+    "--bin"
+    "flakelet-push"
+  ];
+  doCheck = false;
+  meta.mainProgram = "flakelet-push";
+}

--- a/nix/hercules-ci.nix
+++ b/nix/hercules-ci.nix
@@ -1,43 +1,21 @@
-# Enqueue `flakelet update` on the hub and worker hosts, authorized by a
-# step-ca ssh certificate for this repo's main branch.
+# Ask the flakelet relays to update hub and workers, authorized by this
+# repo's nixbot id token (rule "tribuchet" in Mic92/dotfiles
+# nixosModules/flakelet-relay).
 { pkgs, effects }:
 let
-  hosts = [
-    "eve.r"
-    "eliza.r"
-    "jamie.r"
-  ];
+  flakelet-push = pkgs.callPackage ./flakelet-push.nix { };
 in
 { primaryRepo, ... }:
 {
   onPush.default.outputs.effects.deploy = effects.runIf ((primaryRepo.branch or null) == "main") (
     effects.mkEffect {
       name = "deploy";
-      idTokenAudiences = [ "step-ca-ssh" ];
-      inputs = [
-        pkgs.step-cli
-        pkgs.openssh
-      ];
+      idTokenAudiences = [ "flakelet-relay" ];
+      inputs = [ flakelet-push ];
       effectScript = ''
-        export STEPPATH=$PWD/.step
-        step ca bootstrap --ca-url https://ca.r \
-          --fingerprint 759759ea7dc7d635d761ce19a07bc0b3ab02212318e05b49d2b194c60414b84a
-
-        ssh-keygen -t ed25519 -N "" -q -f ./id_deploy
-        step ssh certificate --sign --provisioner nixbot \
-          --token "$(nixbot-id-token step-ca-ssh)" \
-          deploy ./id_deploy.pub
-
-        rc=0
-        for host in ${toString hosts}; do
-          ssh -i ./id_deploy \
-            -o CertificateFile=./id_deploy-cert.pub \
-            -o UserKnownHostsFile=$PWD/known_hosts \
-            -o StrictHostKeyChecking=accept-new \
-            -o ConnectTimeout=10 \
-            "flakelet-deploy@$host" || rc=1
-        done
-        exit $rc
+        export FLAKELET_RELAY_TOKEN_COMMAND="nixbot-id-token flakelet-relay"
+        flakelet-push --relay-srv thalheim.io deploy \
+          eve/tribuchet-hub --wave eliza/tribuchet-worker jamie/tribuchet-worker
       '';
     }
   );


### PR DESCRIPTION
Uses the relays on eve/eva (Mic92/dotfiles nixosModules/flakelet-relay) with this repo's nixbot id token.