### PR TITLE
worker: shut idle agents down after the startup sweep

### DIFF
--- a/crates/tribuchet/src/worker/resume.rs
+++ b/crates/tribuchet/src/worker/resume.rs
@@ -115,12 +115,18 @@ pub(super) async fn adopt_builds(ctx: &Arc<WorkerCtx>) {
 /// Clean up agent builds without an on-disk record, left by a Start
 /// that raced the previous worker's shutdown. They fail every later
 /// Start on their agent with Busy. Runs after adoption, so adopted
-/// agents are already out of the pool.
+/// agents are already out of the pool. The query activates every agent,
+/// so idle ones are told to exit again.
 pub(super) fn sweep_orphaned_agent_builds(ctx: &Arc<WorkerCtx>) {
     for socket in ctx.agents.idle_sockets() {
         let id = match agents::current_build(&socket) {
             Ok(Some(id)) => id,
-            Ok(None) => continue,
+            Ok(None) => {
+                if let Err(e) = agents::shutdown(&socket) {
+                    tracing::warn!("agent shutdown {}: {}", socket.display(), chain(&e));
+                }
+                continue;
+            }
             Err(e) => {
                 tracing::warn!("querying agent {}: {}", socket.display(), chain(&e));
                 continue;

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -317,6 +317,12 @@ in
         hub.wait_until_succeeds(
             "journalctl -u tribuchet-hub | grep -q 'worker registered'"
         )
+        # The startup sweep activates every agent. Idle ones exit again so
+        # they do not pin the binary they were started with.
+        worker.wait_until_succeeds(
+            "test $(systemctl list-units --state=active --no-legend 'tribuchet-agent@*.service' | wc -l) = 0",
+            timeout=30,
+        )
 
     with subtest("worker sshd reachable for the harness backdoor"):
         hub.wait_for_unit("sshd.service")


### PR DESCRIPTION
The startup sweep queries every agent for an orphaned build, which socket-activates all of them. Idle agents only exit on Shutdown, so they all kept running the binary current at worker start and survived later switches (X-RestartIfChanged=false). On jamie 331/384 agents were still the boot-time build after two deploys. Send Shutdown to idle agents in the sweep. Lifecycle test asserts no agent service stays active after registration.
